### PR TITLE
feat(tracker): add RED, HDB, OPS, UNIT3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 [![Donate](https://img.shields.io/badge/Donate-gray.svg?style=flat-square)](#donate)
 
 # tqm
+
 CLI tool to manage your torrent client queues. Primary focus is on removing torrents that meet specific criteria.
 
 This is a fork from [l3uddz](https://github.com/l3uddz/tqm).
 
 ## Example Configuration
+
 ```yaml
 clients:
   deluge:
@@ -105,6 +107,7 @@ filters:
 ```
 
 ## Optional - Tracker Configuration
+
 ```yaml
 trackers:
   bhd:
@@ -112,46 +115,53 @@ trackers:
   ptp:
     api_user: your-api-user
     api_key: your-api-key
+  red:
+    api_key: your-api-key
 ```
+
 Allows tqm to validate if a torrent was removed from the tracker using the tracker's own API.
 
 Currently implements:
+
 - Beyond-HD
 - PTP
 
 ## Filtering Language Definition
+
 The language definition used in the configuration filters is available [here](https://github.com/antonmedv/expr/blob/586b86b462d22497d442adbc924bfb701db3075d/docs/Language-Definition.md)
 
 ## Filterable Fields
+
 The following torrent fields (along with their types) can be used in the configuration when filtering torrents:
+
 ```go
 type Torrent struct {
-	Hash            string  
-	Name            string  
-	Path            string  
-	TotalBytes      int64   
-	DownloadedBytes int64   
-	State           string  
-	Files           []string
-	Tags            []string
-	Downloaded      bool    
-	Seeding         bool    
-	Ratio           float32 
-	AddedSeconds    int64   
-	AddedHours      float32 
-	AddedDays       float32 
-	SeedingSeconds  int64   
-	SeedingHours    float32 
-	SeedingDays     float32 
-	Label           string  
-	Seeds           int64   
-	Peers           int64   
+ Hash            string  
+ Name            string  
+ Path            string  
+ TotalBytes      int64   
+ DownloadedBytes int64   
+ State           string  
+ Files           []string
+ Tags            []string
+ Downloaded      bool    
+ Seeding         bool    
+ Ratio           float32 
+ AddedSeconds    int64   
+ AddedHours      float32 
+ AddedDays       float32 
+ SeedingSeconds  int64   
+ SeedingHours    float32 
+ SeedingDays     float32 
+ Label           string  
+ Seeds           int64   
+ Peers           int64   
 
-	FreeSpaceGB  func() float64 
-	FreeSpaceSet bool
+ FreeSpaceGB  func() float64 
+ FreeSpaceSet bool
 
-	TrackerName   string
-	TrackerStatus string
+ TrackerName   string
+ TrackerStatus string
 }
 ```
 
@@ -164,7 +174,9 @@ Fields of type `[]string` (lists) such as the `Tags` and `Files` fields support 
 All of this and more can be noted in the [language definition](https://github.com/antonmedv/expr/blob/586b86b462d22497d442adbc924bfb701db3075d/docs/Language-Definition.md) mentioned above.
 
 ## Helper Filtering Options
+
 The following helper functions are available for usage while filtering, usage examples are available in the example config above.
+
 ```go
 IsUnregistered() bool // Evaluates to true if torrent is unregistered in the tracker
 HasAllTags(tags ...string) bool // True if torrent has ALL tags specified
@@ -173,8 +185,10 @@ Log(n float64) float64 // The natural logarithm function
 ```
 
 ## BypassIgnoreIfUnregistered
+
 If the top level config option `bypassIgnoreIfUnregistered` is set to `true`, unregistered torrents will not be ignored.
 This helps making the config less verbose, so this:
+
 ```yaml
 filters:
   default:
@@ -188,7 +202,9 @@ filters:
       # Filter based on qbittorrent tags (only qbit at the moment)
       - '"permaseed" in Tags && !IsUnregistered()'
 ```
+
 can turn into this:
+
 ```yaml
 bypassIgnoreIfUnregistered: true
 
@@ -208,10 +224,12 @@ filters:
 **Note:** If `TrackerStatus contains "Tracker is down"` then a torrent will not be considered unregistered anyways and will be ignored when tracker is down assuming the above filters.
 
 ## Supported Clients
+
 - Deluge
 - qBittorrent
 
 ## Example Commands
+
 1. Clean - Retrieve torrent client queue and remove torrents matching its configured filters
 
 `tqm clean qbt --dry-run`

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Currently implements:
 
 - Beyond-HD
 - PTP
+- RED
 
 ## Filtering Language Definition
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ trackers:
   ptp:
     api_user: your-api-user
     api_key: your-api-key
+  hdb:
+    username: your-username
+    passkey: your-passkey
   red:
+    api_key: your-api-key
+  ops:
     api_key: your-api-key
   unit3d:
     aither:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ trackers:
     api_key: your-api-key
   red:
     api_key: your-api-key
+  unit3d:
+    aither:
+      api_key: your_api_key
+      domain: aither.cc
+    blutopia:
+      api_key: your_api_key
+      domain: blutopia.cc
 ```
 
 Allows tqm to validate if a torrent was removed from the tracker using the tracker's own API.
@@ -124,8 +131,11 @@ Allows tqm to validate if a torrent was removed from the tracker using the track
 Currently implements:
 
 - Beyond-HD
+- HDB
+- OPS
 - PTP
 - RED
+- UNIT3D trackers
 
 ## Filtering Language Definition
 

--- a/client/qbittorrent.go
+++ b/client/qbittorrent.go
@@ -96,7 +96,7 @@ func (c *QBittorrent) Connect() error {
 	apiVersion, err := c.client.GetWebAPIVersion()
 	if err != nil {
 		return fmt.Errorf("get api version: %w", err)
-	} 
+	}
 	//else if stringutils.Atof64(apiVersion[0:3], 0.0) < 2.2 {
 	//	return fmt.Errorf("unsupported webapi version: %v", apiVersion)
 	//}
@@ -240,6 +240,7 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 			// tracker
 			TrackerName:   trackerName,
 			TrackerStatus: trackerStatus,
+			Comment:       td.Comment,
 		}
 
 		torrents[t.Hash] = torrent

--- a/config/torrent.go
+++ b/config/torrent.go
@@ -50,6 +50,7 @@ type Torrent struct {
 	// tracker
 	TrackerName   string `json:"TrackerName"`
 	TrackerStatus string `json:"TrackerStatus"`
+	Comment       string `json:"Comment"`
 
 	// set by command
 	HardlinkedOutsideClient bool `json:"-"`

--- a/config/torrent.go
+++ b/config/torrent.go
@@ -108,6 +108,7 @@ func (t *Torrent) IsUnregistered() bool {
 			Seeding:         t.Seeding,
 			TrackerName:     t.TrackerName,
 			TrackerStatus:   t.State,
+			Comment:         t.Comment,
 		}
 
 		if err, ur := tr.IsUnregistered(tt); err == nil {

--- a/tracker/hdb.go
+++ b/tracker/hdb.go
@@ -1,0 +1,104 @@
+package tracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/autobrr/tqm/httputils"
+	"github.com/autobrr/tqm/logger"
+	"github.com/lucperkins/rek"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/ratelimit"
+)
+
+type HDBConfig struct {
+	Username string `koanf:"username"`
+	Passkey  string `koanf:"passkey"`
+}
+
+type HDB struct {
+	cfg  HDBConfig
+	http *http.Client
+	log  *logrus.Entry
+}
+
+func NewHDB(c HDBConfig) *HDB {
+	l := logger.GetLogger("hdb-api")
+	return &HDB{
+		cfg:  c,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		log:  l,
+	}
+}
+
+func (c *HDB) Name() string {
+	return "HDB"
+}
+
+func (c *HDB) Check(host string) bool {
+	return strings.Contains(host, "hdbits.org")
+}
+
+func (c *HDB) IsUnregistered(torrent *Torrent) (error, bool) {
+	//c.log.Infof("Checking HDB torrent: %s", torrent.Name)
+
+	type Request struct {
+		Username string `json:"username"`
+		Passkey  string `json:"passkey"`
+		Hash     string `json:"hash"`
+	}
+
+	type TorrentResult struct {
+		ID   int    `json:"id"`
+		Hash string `json:"hash"`
+		Name string `json:"name"`
+	}
+
+	type Response struct {
+		Status  int             `json:"status"`
+		Message string          `json:"message"`
+		Data    []TorrentResult `json:"data"`
+	}
+
+	// prepare request body
+	reqBody := Request{
+		Username: c.cfg.Username,
+		Passkey:  c.cfg.Passkey,
+		Hash:     strings.ToUpper(torrent.Hash),
+	}
+
+	// send request
+	resp, err := rek.Post("https://hdbits.org/api/torrents",
+		rek.Client(c.http),
+		rek.Json(reqBody),
+	)
+	if err != nil {
+		if resp == nil {
+			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
+			return fmt.Errorf("hdb: request search: %w", err), false
+		}
+	}
+	defer resp.Body().Close()
+
+	// validate response
+	if resp.StatusCode() != 200 {
+		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
+			torrent.Name, torrent.Hash, resp.Status())
+		return fmt.Errorf("hdb: validate search response: %s", resp.Status()), false
+	}
+
+	// decode response
+	b := new(Response)
+	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
+		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
+			torrent.Name, torrent.Hash)
+		return fmt.Errorf("hdb: decode search response: %w", err), false
+	}
+
+	// HDB returns status 0 for success, anything else is an error
+	// if we get no results for a valid hash, the torrent is unregistered
+	return nil, b.Status == 0 && len(b.Data) == 0
+}

--- a/tracker/ops.go
+++ b/tracker/ops.go
@@ -1,0 +1,91 @@
+package tracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/autobrr/tqm/httputils"
+	"github.com/autobrr/tqm/logger"
+	"github.com/lucperkins/rek"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/ratelimit"
+)
+
+type OPSConfig struct {
+	Key string `koanf:"api_key"`
+}
+
+type OPS struct {
+	cfg  OPSConfig
+	http *http.Client
+	log  *logrus.Entry
+}
+
+func NewOPS(c OPSConfig) *OPS {
+	l := logger.GetLogger("ops-api")
+	return &OPS{
+		cfg:  c,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		log:  l,
+	}
+}
+
+func (c *OPS) Name() string {
+	return "OPS"
+}
+
+func (c *OPS) Check(host string) bool {
+	return strings.Contains(host, "opsfet.ch")
+}
+
+func (c *OPS) IsUnregistered(torrent *Torrent) (error, bool) {
+	//c.log.Infof("Checking OPS torrent: %s", torrent.Name)
+
+	type Response struct {
+		Status   string      `json:"status"`
+		Error    string      `json:"error"`
+		Response interface{} `json:"response"`
+		Info     struct {
+			Source  string `json:"source"`
+			Version int    `json:"version"`
+		} `json:"info"`
+	}
+
+	// prepare request
+	url := fmt.Sprintf("https://orpheus.network/ajax.php?action=torrent&hash=%s", strings.ToUpper(torrent.Hash))
+
+	// send request with API key in Authorization header
+	resp, err := rek.Get(url,
+		rek.Client(c.http),
+		rek.Headers(map[string]string{
+			"Authorization": fmt.Sprintf("token %s", c.cfg.Key),
+		}),
+	)
+	if err != nil {
+		if resp == nil {
+			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
+			return fmt.Errorf("ops: request search: %w", err), false
+		}
+	}
+	defer resp.Body().Close()
+
+	// validate response
+	if resp.StatusCode() != 200 {
+		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
+			torrent.Name, torrent.Hash, resp.Status())
+		return fmt.Errorf("ops: validate search response: %s", resp.Status()), false
+	}
+
+	// decode response
+	b := new(Response)
+	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
+		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
+			torrent.Name, torrent.Hash)
+		return fmt.Errorf("ops: decode search response: %w", err), false
+	}
+
+	return nil, b.Status == "failure" && b.Error == "bad parameters"
+}

--- a/tracker/red.go
+++ b/tracker/red.go
@@ -42,6 +42,8 @@ func (c *RED) Check(host string) bool {
 }
 
 func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
+	//c.log.Infof("Checking RED torrent: %s", torrent.Name)
+
 	type Response struct {
 		Status   string `json:"status"`
 		Error    string `json:"error"`
@@ -73,12 +75,7 @@ func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
 	defer resp.Body().Close()
 
 	// validate response
-	if resp.StatusCode() != 200 {
-		if resp.StatusCode() == 400 {
-			c.log.Errorf("Invalid hash for %s (hash: %s), response: %s",
-				torrent.Name, torrent.Hash, resp.Status())
-			return nil, false // Return nil error for invalid hash
-		}
+	if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
 		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
 			torrent.Name, torrent.Hash, resp.Status())
 		return fmt.Errorf("redacted: validate search response: %s", resp.Status()), false

--- a/tracker/red.go
+++ b/tracker/red.go
@@ -1,4 +1,3 @@
-// red.go
 package tracker
 
 import (

--- a/tracker/red.go
+++ b/tracker/red.go
@@ -38,7 +38,7 @@ func (c *RED) Name() string {
 }
 
 func (c *RED) Check(host string) bool {
-	return strings.Contains(host, "redacted.sh")
+	return strings.Contains(host, "flacsfor.me")
 }
 
 func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
@@ -65,8 +65,10 @@ func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
 		}),
 	)
 	if err != nil {
-		c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-		return fmt.Errorf("redacted: request search: %w", err), false
+		if resp == nil {
+			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
+			return fmt.Errorf("redacted: request search: %w", err), false
+		}
 	}
 	defer resp.Body().Close()
 

--- a/tracker/red.go
+++ b/tracker/red.go
@@ -1,0 +1,95 @@
+// red.go
+package tracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/autobrr/tqm/httputils"
+	"github.com/autobrr/tqm/logger"
+	"github.com/lucperkins/rek"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/ratelimit"
+)
+
+type REDConfig struct {
+	Key string `koanf:"api_key"`
+}
+
+type RED struct {
+	cfg  REDConfig
+	http *http.Client
+	log  *logrus.Entry
+}
+
+func NewRED(c REDConfig) *RED {
+	l := logger.GetLogger("red-api")
+	return &RED{
+		cfg:  c,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		log:  l,
+	}
+}
+
+func (c *RED) Name() string {
+	return "RED"
+}
+
+func (c *RED) Check(host string) bool {
+	return strings.Contains(host, "redacted.sh")
+}
+
+func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
+	type Response struct {
+		Status   string `json:"status"`
+		Error    string `json:"error"`
+		Response struct {
+			Group   interface{} `json:"group"`
+			Torrent struct {
+				ID       int    `json:"id"`
+				InfoHash string `json:"infoHash"`
+			} `json:"torrent"`
+		} `json:"response"`
+	}
+
+	// prepare request
+	url := fmt.Sprintf("https://redacted.sh/ajax.php?action=torrent&hash=%s", strings.ToUpper(torrent.Hash))
+
+	// send request with API key in header
+	resp, err := rek.Get(url,
+		rek.Client(c.http),
+		rek.Headers(map[string]string{
+			"Authorization": c.cfg.Key,
+		}),
+	)
+	if err != nil {
+		c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
+		return fmt.Errorf("redacted: request search: %w", err), false
+	}
+	defer resp.Body().Close()
+
+	// validate response
+	if resp.StatusCode() != 200 {
+		if resp.StatusCode() == 400 {
+			c.log.Errorf("Invalid hash for %s (hash: %s), response: %s",
+				torrent.Name, torrent.Hash, resp.Status())
+			return nil, false // Return nil error for invalid hash
+		}
+		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
+			torrent.Name, torrent.Hash, resp.Status())
+		return fmt.Errorf("redacted: validate search response: %s", resp.Status()), false
+	}
+
+	// decode response
+	b := new(Response)
+	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
+		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
+			torrent.Name, torrent.Hash)
+		return fmt.Errorf("redacted: decode search response: %w", err), false
+	}
+
+	return nil, b.Status == "failure" && b.Error == "bad hash parameter"
+}

--- a/tracker/struct.go
+++ b/tracker/struct.go
@@ -3,6 +3,7 @@ package tracker
 type Config struct {
 	BHD BHDConfig
 	PTP PTPConfig
+	RED REDConfig
 }
 
 type Torrent struct {

--- a/tracker/struct.go
+++ b/tracker/struct.go
@@ -3,7 +3,9 @@ package tracker
 type Config struct {
 	BHD BHDConfig
 	PTP PTPConfig
+	HDB HDBConfig
 	RED REDConfig
+	OPS OPSConfig
 }
 
 type Torrent struct {

--- a/tracker/struct.go
+++ b/tracker/struct.go
@@ -1,11 +1,12 @@
 package tracker
 
 type Config struct {
-	BHD BHDConfig
-	PTP PTPConfig
-	HDB HDBConfig
-	RED REDConfig
-	OPS OPSConfig
+	BHD    BHDConfig
+	PTP    PTPConfig
+	HDB    HDBConfig
+	RED    REDConfig
+	OPS    OPSConfig
+	UNIT3D map[string]UNIT3DConfig
 }
 
 type Torrent struct {
@@ -21,4 +22,5 @@ type Torrent struct {
 	// tracker
 	TrackerName   string
 	TrackerStatus string
+	Comment       string
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -17,7 +17,12 @@ func Init(cfg Config) error {
 	if cfg.RED.Key != "" {
 		trackers = append(trackers, NewRED(cfg.RED))
 	}
-
+	if cfg.OPS.Key != "" {
+		trackers = append(trackers, NewOPS(cfg.OPS))
+	}
+	if cfg.HDB.Username != "" && cfg.HDB.Passkey != "" {
+		trackers = append(trackers, NewHDB(cfg.HDB))
+	}
 	return nil
 }
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -14,6 +14,9 @@ func Init(cfg Config) error {
 	if cfg.PTP.User != "" && cfg.PTP.Key != "" {
 		trackers = append(trackers, NewPTP(cfg.PTP))
 	}
+	if cfg.RED.Key != "" {
+		trackers = append(trackers, NewRED(cfg.RED))
+	}
 
 	return nil
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -23,6 +23,11 @@ func Init(cfg Config) error {
 	if cfg.HDB.Username != "" && cfg.HDB.Passkey != "" {
 		trackers = append(trackers, NewHDB(cfg.HDB))
 	}
+	for name, unit3dCfg := range cfg.UNIT3D {
+		if unit3dCfg.APIKey != "" && unit3dCfg.Domain != "" {
+			trackers = append(trackers, NewUNIT3D(name, unit3dCfg))
+		}
+	}
 	return nil
 }
 

--- a/tracker/unit3d.go
+++ b/tracker/unit3d.go
@@ -1,0 +1,148 @@
+package tracker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/autobrr/tqm/httputils"
+	"github.com/autobrr/tqm/logger"
+	"github.com/lucperkins/rek"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/ratelimit"
+)
+
+type UNIT3DConfig struct {
+	APIKey string `koanf:"api_key"`
+	Domain string `koanf:"domain"`
+}
+
+type UNIT3D struct {
+	cfg     UNIT3DConfig
+	http    *http.Client
+	headers map[string]string
+	log     *logrus.Entry
+}
+
+// https://github.com/HDInnovations/UNIT3D-Community-Edition/wiki/Torrent-API-(UNIT3D-v8.3.4)
+func NewUNIT3D(name string, c UNIT3DConfig) Interface {
+	l := logger.GetLogger(fmt.Sprintf("%s-api", strings.ToLower(name)))
+
+	return &UNIT3D{
+		cfg:  c,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		headers: map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", c.APIKey),
+			"Accept":        "application/json",
+		},
+		log: l,
+	}
+}
+
+func (c *UNIT3D) Name() string {
+	return "UNIT3D"
+}
+
+func (c *UNIT3D) Check(host string) bool {
+	return strings.EqualFold(host, c.cfg.Domain)
+}
+
+// extractTorrentID extracts the torrent ID from the comment field
+// example comment: "This torrent was downloaded from aither.cc. https://aither.cc/torrents/123456"
+func (c *UNIT3D) extractTorrentID(comment string) (string, error) {
+	if comment == "" {
+		return "", fmt.Errorf("empty comment field")
+	}
+
+	// extract torrent ID from any URL in the comment that matches our domain
+	re := regexp.MustCompile(fmt.Sprintf(`https?://[^/]*%s/torrents/(\d+)`, regexp.QuoteMeta(c.cfg.Domain)))
+	matches := re.FindStringSubmatch(comment)
+
+	if len(matches) < 2 {
+		return "", fmt.Errorf("no torrent ID found in comment: %s", comment)
+	}
+
+	return matches[1], nil
+}
+
+func (c *UNIT3D) IsUnregistered(torrent *Torrent) (error, bool) {
+	if !strings.EqualFold(torrent.TrackerName, c.cfg.Domain) {
+		return nil, false
+	}
+
+	if torrent.Comment == "" {
+		c.log.Debugf("Skipping torrent check - no comment available (likely Deluge client): %s", torrent.Name)
+		return nil, false
+	}
+
+	c.log.Infof("Checking torrent from %s: %s", torrent.TrackerName, torrent.Name)
+
+	// extract torrent ID from comment
+	torrentID, err := c.extractTorrentID(torrent.Comment)
+	if err != nil {
+		//c.log.Debugf("Skipping torrent check - %v", err)
+		return nil, false
+	}
+
+	type TorrentData struct {
+		Attributes struct {
+			InfoHash string `json:"info_hash"`
+		} `json:"attributes"`
+	}
+
+	type Response struct {
+		Data    TorrentData `json:"data"`
+		Message string      `json:"message"`
+		Status  int         `json:"status"`
+	}
+
+	// prepare request
+	url := fmt.Sprintf("https://%s/api/torrents/%s", c.cfg.Domain, torrentID)
+
+	// send request
+	resp, err := rek.Get(url,
+		rek.Client(c.http),
+		rek.Headers(c.headers),
+	)
+	if err != nil {
+		if resp == nil {
+			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
+			return fmt.Errorf("unit3d: request search: %w", err), false
+		}
+	}
+	defer resp.Body().Close()
+
+	if resp.StatusCode() == 404 {
+		//c.log.Debugf("Torrent not found: %s (hash: %s)", torrent.Name, torrent.Hash)
+		return nil, true
+	}
+
+	// validate other response codes
+	if resp.StatusCode() != 200 {
+		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
+			torrent.Name, torrent.Hash, resp.Status())
+		return fmt.Errorf("unit3d: validate search response: %s", resp.Status()), false
+	}
+
+	// decode response
+	b := new(Response)
+	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
+		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
+			torrent.Name, torrent.Hash)
+		return fmt.Errorf("unit3d: decode search response: %w", err), false
+	}
+
+	// compare info hash
+	if strings.EqualFold(b.Data.Attributes.InfoHash, torrent.Hash) {
+		// torrent exists and hash matches
+		return nil, false
+	}
+
+	// if we get here, the torrent ID exists but hash doesn't match
+	c.log.Debugf("Torrent ID exists but hash mismatch. Expected: %s, Got: %s",
+		torrent.Hash, b.Data.Attributes.InfoHash)
+	return nil, true
+}

--- a/tracker/unit3d.go
+++ b/tracker/unit3d.go
@@ -58,7 +58,7 @@ func (c *UNIT3D) extractTorrentID(comment string) (string, error) {
 	}
 
 	// extract torrent ID from any URL in the comment that matches our domain
-	re := regexp.MustCompile(fmt.Sprintf(`https?://[^/]*%s/torrents/(\d+)`, regexp.QuoteMeta(c.cfg.Domain)))
+	re := regexp.MustCompile(fmt.Sprintf(`https?://[^/]*%s/(?:torrents|details)/(\d+)`, regexp.QuoteMeta(c.cfg.Domain)))
 	matches := re.FindStringSubmatch(comment)
 
 	if len(matches) < 2 {


### PR DESCRIPTION
This adds API check fallback if no match is found in `unregisteredStatuses` for the following:

- UNIT3D Generic **(Requires a torrent URL to be present in `Torrent Comment`)**
- RED
- OPS
- HDB

Currently untested, as I don't have any unregistered torrents.