### PR TITLE
fix(torrent): disable match on "truncated"

### DIFF
--- a/config/torrent.go
+++ b/config/torrent.go
@@ -38,7 +38,7 @@ var (
 		"tracker nicht registriert",
 		"torrent not found",
 		"trump",
-		"truncated",
+		//"truncated", // Tracker is down
 		"unknown",
 		"unregistered",
 		"upgraded",


### PR DESCRIPTION
`stream truncated` is typical for trackers that are down. E.g. BLU and FL.