### PR TITLE
fix: path check for Deluge when using FreeSpaceGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,15 +310,6 @@ filters:
 
 #### Availability
 
-These features are currently only supported for:
-
-- **Deluge**: Requires `free_space_path` to be set to a valid path on the server
-- **qBittorrent**: Works without `free_space_path` as it retrieves global free space information via API
-
-#### Configuration Differences
-
-**IMPORTANT**: How the `free_space_path` setting works depends on your client type:
-
 - For **Deluge**, `free_space_path` must be set and point to a valid path on your server
 - For **qBittorrent**, the `free_space_path` parameter is not needed and can be omitted
 
@@ -326,7 +317,6 @@ These features are currently only supported for:
 
 1. Free space information is retrieved when a command is run
 2. If successful, `FreeSpaceSet` becomes `true` and `FreeSpaceGB()` will return the available space in gigabytes
-3. As torrents are removed, `FreeSpaceGB()` will automatically increase by the size of the removed torrent
 
 #### Using in Filters
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ clients:
     enabled: true
     filter: default
     download_path: /mnt/local/downloads/torrents/deluge
-    free_space_path: /mnt/local/downloads/torrents/deluge
+    free_space_path: /mnt/local/downloads/torrents/deluge  # Required for Deluge with path that exists on server
     download_path_mapping:
       /downloads/torrents/deluge: /mnt/local/downloads/torrents/deluge
     host: localhost
@@ -29,6 +29,7 @@ clients:
     v2: true
   qbt:
     download_path: /mnt/local/downloads/torrents/qbittorrent/completed
+    # free_space_path is not needed for qBittorrent as it checks globally via API
     download_path_mapping:
       /downloads/torrents/qbittorrent/completed: /mnt/local/downloads/torrents/qbittorrent/completed
     enabled: true
@@ -303,14 +304,40 @@ filters:
 
 ## Notes
 
-`FreeSpaceSet` and `FreeSpaceGB()` are currently only supported for the following clients (when `free_space_path` is set):
+### Free Space Tracking
 
-- Deluge
-- qBittorrent
+`FreeSpaceSet` and `FreeSpaceGB()` are available for tracking free disk space in your filters. These allow you to make decisions based on available disk space and track space changes as torrents are removed.
 
-`FreeSpaceGB()` will only increase as torrents are hard-removed.
+#### Availability
 
-This only works with one disk referenced by `free_space_path` and will not account for torrents being on **different disks**.
+These features are currently only supported for:
+
+- **Deluge**: Requires `free_space_path` to be set to a valid path on the server
+- **qBittorrent**: Works without `free_space_path` as it retrieves global free space information via API
+
+#### Configuration Differences
+
+**IMPORTANT**: How the `free_space_path` setting works depends on your client type:
+
+- For **Deluge**, `free_space_path` must be set and point to a valid path on your server
+- For **qBittorrent**, the `free_space_path` parameter is not needed and can be omitted
+
+#### How It Works
+
+1. Free space information is retrieved when a command is run
+2. If successful, `FreeSpaceSet` becomes `true` and `FreeSpaceGB()` will return the available space in gigabytes
+3. As torrents are removed, `FreeSpaceGB()` will automatically increase by the size of the removed torrent
+
+#### Using in Filters
+
+You can use these values in your filter expressions:
+
+```yaml
+filters:
+  default:
+    remove:
+      - FreeSpaceSet == true && FreeSpaceGB() < 100 && SeedingDays > 30
+```
 
 ## regexp2 Pattern Matching
 

--- a/client/deluge.go
+++ b/client/deluge.go
@@ -250,7 +250,7 @@ func (c *Deluge) SetTorrentLabel(hash string, label string, hardlink bool) error
 
 func (c *Deluge) GetCurrentFreeSpace(path string) (int64, error) {
 	if path == "" {
-		return 0, fmt.Errorf("empty path provided for free space check")
+		return 0, fmt.Errorf("free_space_path is not set for deluge")
 	}
 
 	// get free disk space

--- a/client/deluge.go
+++ b/client/deluge.go
@@ -249,6 +249,10 @@ func (c *Deluge) SetTorrentLabel(hash string, label string, hardlink bool) error
 }
 
 func (c *Deluge) GetCurrentFreeSpace(path string) (int64, error) {
+	if path == "" {
+		return 0, fmt.Errorf("empty path provided for free space check")
+	}
+
 	// get free disk space
 	space, err := c.client.GetFreeSpace(path)
 	if err != nil {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -97,6 +97,15 @@ var cleanCmd = &cobra.Command{
 				log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
 					humanize.IBytes(uint64(space)), c.GetFreeSpace())
 			}
+		} else if *clientType == "qbittorrent" {
+			// For qBittorrent, we can get free space without a path
+			space, err := c.GetCurrentFreeSpace("")
+			if err != nil {
+				log.WithError(err).Warn("Failed retrieving free-space")
+			} else {
+				log.Infof("Retrieved free-space: %v (%.2f GB)",
+					humanize.IBytes(uint64(space)), c.GetFreeSpace())
+			}
 		}
 
 		// retrieve torrents

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/autobrr/tqm/client"
@@ -89,22 +91,34 @@ var cleanCmd = &cobra.Command{
 		}
 
 		// get free disk space (can/will be used by filters)
-		if clientFreeSpacePath != nil {
-			space, err := c.GetCurrentFreeSpace(*clientFreeSpacePath)
-			if err != nil {
-				log.WithError(err).Warnf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
-			} else {
-				log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
-					humanize.IBytes(uint64(space)), c.GetFreeSpace())
-			}
-		} else if *clientType == "qbittorrent" {
+		switch *clientType {
+		case "qbittorrent":
 			// For qBittorrent, we can get free space without a path
 			space, err := c.GetCurrentFreeSpace("")
 			if err != nil {
-				log.WithError(err).Warn("Failed retrieving free-space")
+				log.WithError(err).Error("Failed retrieving free-space")
 			} else {
 				log.Infof("Retrieved free-space: %v (%.2f GB)",
 					humanize.IBytes(uint64(space)), c.GetFreeSpace())
+			}
+
+		case "deluge":
+			if clientFreeSpacePath != nil {
+				space, err := c.GetCurrentFreeSpace(*clientFreeSpacePath)
+				if err != nil {
+					log.WithError(err).Errorf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
+					os.Exit(1)
+				} else {
+					log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
+						humanize.IBytes(uint64(space)), c.GetFreeSpace())
+				}
+			} else {
+				filterUsesFreespace := checkFilterUsesFreespace(clientFilter)
+
+				if filterUsesFreespace {
+					log.Error("Deluge requires free_space_path to be configured in order to retrieve free space information")
+					os.Exit(1)
+				}
 			}
 		}
 
@@ -166,4 +180,44 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 
 	cleanCmd.Flags().StringVar(&flagFilterName, "filter", "", "Filter to use instead of client")
+}
+
+// checkFilterUsesFreespace checks if any filter conditions use FreeSpaceGB or FreeSpaceSet
+func checkFilterUsesFreespace(filter *config.FilterConfiguration) bool {
+	// Helper function to check a single expression for free space usage
+	checkExpression := func(expr string) bool {
+		return strings.Contains(expr, "FreeSpaceGB") || strings.Contains(expr, "FreeSpaceSet")
+	}
+
+	// Check all filter conditions
+	for _, expr := range filter.Ignore {
+		if checkExpression(expr) {
+			return true
+		}
+	}
+	for _, expr := range filter.Remove {
+		if checkExpression(expr) {
+			return true
+		}
+	}
+
+	// Check label expressions
+	for _, label := range filter.Label {
+		for _, expr := range label.Update {
+			if checkExpression(expr) {
+				return true
+			}
+		}
+	}
+
+	// Check tag expressions
+	for _, tag := range filter.Tag {
+		for _, expr := range tag.Update {
+			if checkExpression(expr) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/cmd/relabel.go
+++ b/cmd/relabel.go
@@ -97,6 +97,15 @@ var relabelCmd = &cobra.Command{
 				log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
 					humanize.IBytes(uint64(space)), c.GetFreeSpace())
 			}
+		} else if *clientType == "qbittorrent" {
+			// For qBittorrent, we can get free space without a path
+			space, err := c.GetCurrentFreeSpace("")
+			if err != nil {
+				log.WithError(err).Warn("Failed retrieving free-space")
+			} else {
+				log.Infof("Retrieved free-space: %v (%.2f GB)",
+					humanize.IBytes(uint64(space)), c.GetFreeSpace())
+			}
 		}
 
 		// load client label path map

--- a/cmd/relabel.go
+++ b/cmd/relabel.go
@@ -92,7 +92,7 @@ var relabelCmd = &cobra.Command{
 		if clientFreeSpacePath != nil {
 			space, err := c.GetCurrentFreeSpace(*clientFreeSpacePath)
 			if err != nil {
-				log.WithError(err).Warnf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
+				log.WithError(err).Errorf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
 			} else {
 				log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
 					humanize.IBytes(uint64(space)), c.GetFreeSpace())
@@ -101,7 +101,7 @@ var relabelCmd = &cobra.Command{
 			// For qBittorrent, we can get free space without a path
 			space, err := c.GetCurrentFreeSpace("")
 			if err != nil {
-				log.WithError(err).Warn("Failed retrieving free-space")
+				log.WithError(err).Error("Failed retrieving free-space")
 			} else {
 				log.Infof("Retrieved free-space: %v (%.2f GB)",
 					humanize.IBytes(uint64(space)), c.GetFreeSpace())

--- a/cmd/retag.go
+++ b/cmd/retag.go
@@ -101,7 +101,7 @@ var retagCmd = &cobra.Command{
 		if clientFreeSpacePath != nil {
 			space, err := ct.GetCurrentFreeSpace(*clientFreeSpacePath)
 			if err != nil {
-				log.WithError(err).Warnf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
+				log.WithError(err).Errorf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
 			} else {
 				log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
 					humanize.IBytes(uint64(space)), ct.GetFreeSpace())
@@ -110,7 +110,7 @@ var retagCmd = &cobra.Command{
 			// For qBittorrent, we can get free space without a path
 			space, err := ct.GetCurrentFreeSpace("")
 			if err != nil {
-				log.WithError(err).Warn("Failed retrieving free-space")
+				log.WithError(err).Error("Failed retrieving free-space")
 			} else {
 				log.Infof("Retrieved free-space: %v (%.2f GB)",
 					humanize.IBytes(uint64(space)), ct.GetFreeSpace())

--- a/cmd/retag.go
+++ b/cmd/retag.go
@@ -106,6 +106,15 @@ var retagCmd = &cobra.Command{
 				log.Infof("Retrieved free-space for %q: %v (%.2f GB)", *clientFreeSpacePath,
 					humanize.IBytes(uint64(space)), ct.GetFreeSpace())
 			}
+		} else if *clientType == "qbittorrent" {
+			// For qBittorrent, we can get free space without a path
+			space, err := ct.GetCurrentFreeSpace("")
+			if err != nil {
+				log.WithError(err).Warn("Failed retrieving free-space")
+			} else {
+				log.Infof("Retrieved free-space: %v (%.2f GB)",
+					humanize.IBytes(uint64(space)), ct.GetFreeSpace())
+			}
 		}
 
 		// retrieve torrents


### PR DESCRIPTION
- Update README to clarify free space path behavior for different clients
- Modify Deluge client to validate free space path input
- Update clean, relabel, and retag commands to handle qBittorrent free space checks

Testing just fine with my qbit and deluge instances.

Program will now exit early if `FreeSpaceGB()` and/or `FreeSpaceSet()` is used in a config and `free_space_path` is not set for Deluge.