### PR TITLE
fix(clean): update hardlink map before file deletion

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -184,6 +184,9 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 		log.Infof("Ratio: %.3f / Seed days: %.3f / Seeds: %d / Label: %s / Tags: %s / Tracker: %s / "+
 			"Tracker Status: %q", t.Ratio, t.SeedingDays, t.Seeds, t.Label, strings.Join(t.Tags, ", "), t.TrackerName, t.TrackerStatus)
 
+		// update the hardlink map before removing the torrent files
+		hfm.RemoveByTorrent(*t)
+
 		if !flagDryRun {
 			// do remove
 			removed, err := c.RemoveTorrent(t.Hash, true)
@@ -221,7 +224,6 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 
 		// remove the torrent from the torrent maps
 		tfm.Remove(*t)
-		hfm.RemoveByTorrent(*t)
 		delete(torrents, h)
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -228,7 +228,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 	}
 
 	// iterate torrents
-	canidates := make(map[string]config.Torrent)
+	candidates := make(map[string]config.Torrent)
 	for h, t := range torrents {
 		// should we ignore this torrent?
 		ignore, err := c.ShouldIgnore(&t)
@@ -263,14 +263,14 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 		// are the files unique and eligible for a hard deletion (remove data)
 		if !tfm.IsUnique(t) {
 			log.Warnf("Skipping non unique torrent | Name: %s / Label: %s / Tags: %s / Tracker: %s", t.Name, t.Label, strings.Join(t.Tags, ", "), t.TrackerName)
-			canidates[h] = t
+			candidates[h] = t
 			continue
 		}
 
 		// are the files not hardlinked to other torrents
 		if !hfm.IsTorrentUnique(t) {
 			log.Warnf("Skipping non unique torrent (hardlinked) | Name: %s / Label: %s / Tags: %s / Tracker: %s", t.Name, t.Label, strings.Join(t.Tags, ", "), t.TrackerName)
-			canidates[h] = t
+			candidates[h] = t
 			continue
 		}
 
@@ -278,20 +278,20 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 	}
 
 	log.Info("========================================")
-	log.Infof("Finished initial check, %d cross-seeded torrents are canidates for removal", len(canidates))
+	log.Infof("Finished initial check, %d cross-seeded torrents are candidates for removal", len(candidates))
 	log.Info("========================================")
 
-	// imagine we removed all canidates,
-	// now lets check if the canidates still have more versions
+	// imagine we removed all candidates,
+	// now lets check if the candidates still have more versions
 	// or can be safely removed
-	for _, t := range canidates {
+	for _, t := range candidates {
 		tfm.Remove(t)
 		hfm.RemoveByTorrent(t)
 	}
 
 	// check again for unique torrents
-	removedCanidates := 0
-	for h, t := range canidates {
+	removedCandidates := 0
+	for h, t := range candidates {
 		noInstances := tfm.NoInstances(t) && hfm.NoInstances(t)
 
 		if !noInstances {
@@ -300,14 +300,14 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 		}
 
 		removeTorrent(h, &t)
-		removedCanidates++
+		removedCandidates++
 	}
 
 	// show result
 	log.Info("-----")
 	log.Infof("Ignored torrents: %d", ignoredTorrents)
 	log.WithField("reclaimed_space", humanize.IBytes(uint64(removedTorrentBytes))).
-		Infof("Removed torrents: %d initially removed, %d cross-seeded torrents were canidates for removal, only %d of them removed and %d failures",
-			hardRemoveTorrents-removedCanidates, len(canidates), removedCanidates, errorRemoveTorrents)
+		Infof("Removed torrents: %d initially removed, %d cross-seeded torrents were candidates for removal, only %d of them removed and %d failures",
+			hardRemoveTorrents-removedCandidates, len(candidates), removedCandidates, errorRemoveTorrents)
 	return nil
 }


### PR DESCRIPTION
Fixed the order, so it doesn't try to stat files *after* they've been deleted.

The bug:
```
[2025-03-03T17:42:46+01:00]  INFO clean          : removing: "Lovely.Runner.2024.S01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@AvistaZ" - 9.6 GiB
[2025-03-03T17:42:46+01:00]  INFO clean          : Ratio: 19.298 / Seed days: 276.257 / Seeds: 107 / Label: sonarrkorean-imported / Tags:  / Tracker: avistaz.to / Tracker Status: ""
[2025-03-03T17:42:51+01:00]  INFO clean          : Removed
[2025-03-03T17:42:52+01:00]  WARN hardlinkfilemap: Failed to stat file: /mnt/local/downloads/torrents/qbittorrent/completed/Lovely.Runner.2024.S01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@AvistaZ/Lovely.Runner.2024.S01E01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@Avistaz.mkv - stat /mnt/local/downloads/torrents/qbittorrent/completed/Lovely.Runner.2024.S01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@AvistaZ/Lovely.Runner.2024.S01E01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@Avistaz.mkv: no such file or directory
[2025-03-03T17:42:52+01:00]  WARN hardlinkfilemap: Failed to stat file: /mnt/local/downloads/torrents/qbittorrent/completed/Lovely.Runner.2024.S01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@AvistaZ/Lovely.Runner.2024.S01E02.1080p.Viki.WEB-DL.AAC2.0.x264-unco@Avistaz.mkv - stat /mnt/local/downloads/torrents/qbittorrent/completed/Lovely.Runner.2024.S01.1080p.Viki.WEB-DL.AAC2.0.x264-unco@AvistaZ/Lovely.Runner.2024.S01E02.1080p.Viki.WEB-DL.AAC2.0.x264-unco@Avistaz.mkv: no such file or directory
```

The fix:
```
[2025-03-03T22:02:31Z]  INFO clean          : removing: "Whiskey.on.the.Rocks.S01.1080p.DSNP.WEB-DL.DD+5.1.H.264-playWEB" - 6.0 GiB
[2025-03-03T22:02:31Z]  INFO clean          : Ratio: 1.699 / Seed days: 26.043 / Seeds: 28 / Label: tv / Tags: fl, season-pack-hd / Tracker: filelist.io / Tracker Status: ""
[2025-03-03T22:02:36Z]  INFO clean          : Removed
[2025-03-03T22:02:37Z]  INFO clean          : ========================================
[2025-03-03T22:02:37Z]  INFO clean          : Finished initial check, 0 cross-seeded torrents are canidates for removal
[2025-03-03T22:02:37Z]  INFO clean          : ========================================
[2025-03-03T22:02:37Z]  INFO clean          : -----
[2025-03-03T22:02:37Z]  INFO clean          : Ignored torrents: 24
[2025-03-03T22:02:37Z]  INFO clean          : Removed torrents: 1 initially removed, 0 cross-seeded torrents were canidates for removal, only 0 of them removed and 0 failures reclaimed_space=6.0 GiB
```