### PR TITLE
feat(clean): optionally keep data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ clients:
 filters:
   default:
     # if true, data will be deleted from disk when removing torrents (default: true)
-    #delete_data: true
+    #delete_data: false
     ignore:
       # general
       - IsTrackerDown()

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ clients:
 filters:
   default:
     # if true, data will be deleted from disk when removing torrents (default: true)
-    delete_data: true
+    #delete_data: true
     ignore:
       # general
       - IsTrackerDown()

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ clients:
     # enableAutoTmmAfterRelabel: true
 filters:
   default:
+    # if true, data will be deleted from disk when removing torrents (default: true)
+    delete_data: true
     ignore:
       # general
       - IsTrackerDown()

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -147,7 +147,7 @@ var cleanCmd = &cobra.Command{
 		}
 
 		// remove torrents that are not ignored and match remove criteria
-		if err := removeEligibleTorrents(log, c, torrents, tfm, hfm); err != nil {
+		if err := removeEligibleTorrents(log, c, torrents, tfm, hfm, clientFilter); err != nil {
 			log.WithError(err).Fatal("Failed removing eligible torrents...")
 		}
 	},

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -162,7 +162,7 @@ func relabelEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map
 
 // remove torrents that meet remove filters
 func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[string]config.Torrent,
-	tfm *torrentfilemap.TorrentFileMap, hfm hardlinkfilemap.HardlinkFileMapI) error {
+	tfm *torrentfilemap.TorrentFileMap, hfm hardlinkfilemap.HardlinkFileMapI, filter *config.FilterConfiguration) error {
 	// vars
 	ignoredTorrents := 0
 	hardRemoveTorrents := 0
@@ -185,8 +185,13 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 			"Tracker Status: %q", t.Ratio, t.SeedingDays, t.Seeds, t.Label, strings.Join(t.Tags, ", "), t.TrackerName, t.TrackerStatus)
 
 		if !flagDryRun {
+			deleteData := true
+			if filter != nil {
+				deleteData = filter.DeleteData
+			}
+
 			// do remove
-			removed, err := c.RemoveTorrent(t.Hash, true)
+			removed, err := c.RemoveTorrent(t.Hash, deleteData)
 			if err != nil {
 				log.WithError(err).Fatalf("Failed removing torrent: %+v", t)
 				// dont remove from torrents file map, but prevent further operations on this torrent
@@ -200,7 +205,11 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 				errorRemoveTorrents++
 				return
 			} else {
-				log.Info("Removed")
+				if deleteData {
+					log.Info("Removed with data")
+				} else {
+					log.Info("Removed (kept data on disk)")
+				}
 
 				// increase free space
 				if t.FreeSpaceSet {

--- a/config/filter.go
+++ b/config/filter.go
@@ -4,7 +4,7 @@ type FilterConfiguration struct {
 	MapHardlinksFor []string
 	Ignore          []string
 	Remove          []string
-	DeleteData      bool `yaml:"delete_data,omitempty" default:"true"`
+	DeleteData      bool
 	Label           []struct {
 		Name   string
 		Update []string

--- a/config/filter.go
+++ b/config/filter.go
@@ -4,6 +4,7 @@ type FilterConfiguration struct {
 	MapHardlinksFor []string
 	Ignore          []string
 	Remove          []string
+	DeleteData      bool `yaml:"delete_data,omitempty" default:"true"`
 	Label           []struct {
 		Name   string
 		Update []string


### PR DESCRIPTION
Users can now optionally keep data on disk when running `clean`. Default behaviour will be`delete_data: true` for backwards compatibility.