### PR TITLE
fix: remove "not found" from unregisteredStatuses

### DIFF
--- a/config/torrent.go
+++ b/config/torrent.go
@@ -20,7 +20,7 @@ var (
 		"infohash not found",
 		"internal available",
 		"not exist",
-		"not found",
+		//"not found", // this is causing too many false positives
 		"not registered",
 		"nuked",
 		"pack is available",


### PR DESCRIPTION
This one is causing too many false positives.