### PR TITLE
fix(docs): config example code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ orphan:
 
 ## Optional - Tracker Configuration
 
-```yaml
 trackers:
   bhd:
     api_key: your-api-key


### PR DESCRIPTION
Removes the additional start for a yaml code block from the config example code block.