### PR TITLE
feat(qbit): include trackers with torrents list or fallback to fetch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.2
 
 require (
-	github.com/autobrr/go-qbittorrent v1.12.0
+	github.com/autobrr/go-qbittorrent v1.13.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89
 	github.com/charlievieth/fastwalk v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/autobrr/go-qbittorrent v1.12.0 h1:TZoutIytmvnTNcj2FjuA2II4ouQsyxYr16H+EOwho5E=
 github.com/autobrr/go-qbittorrent v1.12.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
+github.com/autobrr/go-qbittorrent v1.13.0 h1:cD/jSTnSRFozEiQNp6EkNm5GBizQubUav3vFw+v8g6k=
+github.com/autobrr/go-qbittorrent v1.13.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -141,7 +141,7 @@ func (c *QBittorrent) LabelPathMap() map[string]string {
 func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 	// retrieve torrents from client
 	c.log.Tracef("Retrieving torrents...")
-	t, err := c.client.GetTorrents(qbit.TorrentFilterOptions{})
+	t, err := c.client.GetTorrents(qbit.TorrentFilterOptions{IncludeTrackers: true})
 	if err != nil {
 		return nil, fmt.Errorf("get torrents: %w", err)
 	}
@@ -150,18 +150,11 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 	// build torrent list
 	torrents := make(map[string]config.Torrent)
 	for _, t := range t {
-		t := t
-
 		// get additional torrent details
 		//td, err := c.client.Torrent.GetProperties(t.Hash)
 		td, err := c.client.GetTorrentProperties(t.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("get torrent properties: %v: %w", t.Hash, err)
-		}
-
-		ts, err := c.client.GetTorrentTrackers(t.Hash)
-		if err != nil {
-			return nil, fmt.Errorf("get torrent trackers: %v: %w", t.Hash, err)
 		}
 
 		tf, err := c.client.GetFilesInformation(t.Hash)
@@ -173,7 +166,20 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 		trackerName := ""
 		trackerStatus := ""
 
-		for _, tracker := range ts {
+		var trackers []qbit.TorrentTracker
+
+		// in qBittorrent v5.1+ we can use includeTrackers to populate trackers, but in older versions we need to fetch trackers per torrent
+		if len(t.Trackers) > 0 {
+			trackers = t.Trackers
+		} else {
+			ts, err := c.client.GetTorrentTrackers(t.Hash)
+			if err != nil {
+				return nil, fmt.Errorf("get torrent trackers: %v: %w", t.Hash, err)
+			}
+			trackers = ts
+		}
+
+		for _, tracker := range trackers {
 			// skip disabled trackers
 			if strings.Contains(tracker.Url, "[DHT]") || strings.Contains(tracker.Url, "[LSD]") ||
 				strings.Contains(tracker.Url, "[PeX]") {

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -168,10 +168,10 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 
 		var trackers []qbit.TorrentTracker
 
+		trackers = t.Trackers
+
 		// in qBittorrent v5.1+ we can use includeTrackers to populate trackers, but in older versions we need to fetch trackers per torrent
-		if len(t.Trackers) > 0 {
-			trackers = t.Trackers
-		} else {
+		if len(t.Trackers) == 0 {
 			ts, err := c.client.GetTorrentTrackers(t.Hash)
 			if err != nil {
 				return nil, fmt.Errorf("get torrent trackers: %v: %w", t.Hash, err)


### PR DESCRIPTION
Implement new `includeTrackers` on torrent list fetch to include trackers in a single call, or fall back to fetch per torrent.