### PR TITLE
refactor: pass context to external calls

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -96,7 +96,7 @@ var cleanCmd = &cobra.Command{
 		switch *clientType {
 		case "qbittorrent":
 			// For qBittorrent, we can get free space without a path
-			space, err := c.GetCurrentFreeSpace(nil, "")
+			space, err := c.GetCurrentFreeSpace(ctx, "")
 			if err != nil {
 				log.WithError(err).Error("Failed retrieving free-space")
 			} else {
@@ -106,7 +106,7 @@ var cleanCmd = &cobra.Command{
 
 		case "deluge":
 			if clientFreeSpacePath != nil {
-				space, err := c.GetCurrentFreeSpace(nil, *clientFreeSpacePath)
+				space, err := c.GetCurrentFreeSpace(ctx, *clientFreeSpacePath)
 				if err != nil {
 					log.WithError(err).Errorf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
 					os.Exit(1)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -26,6 +26,8 @@ var cleanCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
 		// init core
 		if !initialized {
 			initCore(true)
@@ -84,7 +86,7 @@ var cleanCmd = &cobra.Command{
 		log.Infof("Initialized client %q, type: %s (%d trackers)", clientName, c.Type(), tracker.Loaded())
 
 		// connect to client
-		if err := c.Connect(); err != nil {
+		if err := c.Connect(ctx); err != nil {
 			log.WithError(err).Fatal("Failed connecting")
 		} else {
 			log.Debugf("Connected to client")
@@ -94,7 +96,7 @@ var cleanCmd = &cobra.Command{
 		switch *clientType {
 		case "qbittorrent":
 			// For qBittorrent, we can get free space without a path
-			space, err := c.GetCurrentFreeSpace("")
+			space, err := c.GetCurrentFreeSpace(nil, "")
 			if err != nil {
 				log.WithError(err).Error("Failed retrieving free-space")
 			} else {
@@ -104,7 +106,7 @@ var cleanCmd = &cobra.Command{
 
 		case "deluge":
 			if clientFreeSpacePath != nil {
-				space, err := c.GetCurrentFreeSpace(*clientFreeSpacePath)
+				space, err := c.GetCurrentFreeSpace(nil, *clientFreeSpacePath)
 				if err != nil {
 					log.WithError(err).Errorf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
 					os.Exit(1)
@@ -123,7 +125,7 @@ var cleanCmd = &cobra.Command{
 		}
 
 		// retrieve torrents
-		torrents, err := c.GetTorrents()
+		torrents, err := c.GetTorrents(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed retrieving torrents")
 		} else {
@@ -170,7 +172,7 @@ var cleanCmd = &cobra.Command{
 		}
 
 		// remove torrents that are not ignored and match remove criteria
-		if err := removeEligibleTorrents(log, c, torrents, tfm, hfm, clientFilter); err != nil {
+		if err := removeEligibleTorrents(ctx, log, c, torrents, tfm, hfm, clientFilter); err != nil {
 			log.WithError(err).Fatal("Failed removing eligible torrents...")
 		}
 	},

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -26,7 +27,7 @@ func removeSlice(slice []string, remove []string) []string {
 }
 
 // retag torrent that meet required filters
-func retagEligibleTorrents(log *logrus.Entry, c client.TagInterface, torrents map[string]config.Torrent) error {
+func retagEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.TagInterface, torrents map[string]config.Torrent) error {
 	// vars
 	ignoredTorrents := 0
 	retaggedTorrents := 0
@@ -79,7 +80,7 @@ func retagEligibleTorrents(log *logrus.Entry, c client.TagInterface, torrents ma
 		if !flagDryRun {
 			// apply tag changes
 			if len(retagInfo.Add) > 0 {
-				if err := c.AddTags(t.Hash, retagInfo.Add); err != nil {
+				if err := c.AddTags(ctx, t.Hash, retagInfo.Add); err != nil {
 					log.WithError(err).Errorf("Failed adding tags %v to torrent: %+v", retagInfo.Add, t)
 					actionFailed = true
 				} else {
@@ -88,7 +89,7 @@ func retagEligibleTorrents(log *logrus.Entry, c client.TagInterface, torrents ma
 				}
 			}
 			if len(retagInfo.Remove) > 0 && !actionFailed {
-				if err := c.RemoveTags(t.Hash, retagInfo.Remove); err != nil {
+				if err := c.RemoveTags(ctx, t.Hash, retagInfo.Remove); err != nil {
 					log.WithError(err).Errorf("Failed removing tags %v from torrent: %+v", retagInfo.Remove, t)
 					actionFailed = true
 				} else {
@@ -103,7 +104,7 @@ func retagEligibleTorrents(log *logrus.Entry, c client.TagInterface, torrents ma
 				if *retagInfo.UploadKb == -1 {
 					limitBytes = -1
 				}
-				if err := c.SetUploadLimit(t.Hash, limitBytes); err != nil {
+				if err := c.SetUploadLimit(ctx, t.Hash, limitBytes); err != nil {
 					log.WithError(err).Errorf("Failed setting upload limit to %d KiB/s for torrent: %+v", *retagInfo.UploadKb, t)
 					actionFailed = true
 				} else {
@@ -135,7 +136,7 @@ func retagEligibleTorrents(log *logrus.Entry, c client.TagInterface, torrents ma
 }
 
 // relabel torrent that meet required filters
-func relabelEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[string]config.Torrent,
+func relabelEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Interface, torrents map[string]config.Torrent,
 	tfm *torrentfilemap.TorrentFileMap) error {
 	// vars
 	ignoredTorrents := 0
@@ -187,7 +188,7 @@ func relabelEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map
 			"Tracker Status: %q", t.Ratio, t.SeedingDays, t.Seeds, t.Label, strings.Join(t.Tags, ", "), t.TrackerName, t.TrackerStatus)
 
 		if !flagDryRun {
-			if err := c.SetTorrentLabel(t.Hash, label, hardlink); err != nil {
+			if err := c.SetTorrentLabel(ctx, t.Hash, label, hardlink); err != nil {
 				log.WithError(err).Fatalf("Failed relabeling torrent: %+v", t)
 				errorRelabelTorrents++
 				continue
@@ -213,7 +214,7 @@ func relabelEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map
 }
 
 // remove torrents that meet remove filters
-func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[string]config.Torrent,
+func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Interface, torrents map[string]config.Torrent,
 	tfm *torrentfilemap.TorrentFileMap, hfm hardlinkfilemap.HardlinkFileMapI, filter *config.FilterConfiguration) error {
 	// vars
 	ignoredTorrents := 0
@@ -227,9 +228,9 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 	}
 
 	// helper function to handle removal of torrents that aren't unique
-	handleNonUniqueTorrent := func(h string, t *config.Torrent, isHardlinked bool) bool {
+	handleNonUniqueTorrent := func(ctx context.Context, h string, t *config.Torrent, isHardlinked bool) bool {
 		// Check if torrent is unregistered (can bypass uniqueness checks)
-		if t.IsUnregistered() {
+		if t.IsUnregistered(ctx) {
 			// For unregistered torrents, override safety checks
 			log.Info("-----")
 			if isHardlinked {
@@ -253,7 +254,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 					localDeleteData = false
 				}
 
-				removed, err := c.RemoveTorrent(t.Hash, localDeleteData)
+				removed, err := c.RemoveTorrent(ctx, t.Hash, localDeleteData)
 				if err != nil {
 					log.WithError(err).Errorf("Failed removing torrent: %+v", t)
 					// dont remove from torrents file map, but prevent further operations on this torrent
@@ -310,7 +311,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 	}
 
 	// helper function to remove torrent
-	removeTorrent := func(h string, t *config.Torrent) {
+	removeTorrent := func(ctx context.Context, h string, t *config.Torrent) {
 		// remove the torrent
 		log.Info("-----")
 		if !t.FreeSpaceSet {
@@ -329,7 +330,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 
 		if !flagDryRun {
 			// do remove
-			removed, err := c.RemoveTorrent(t.Hash, deleteData)
+			removed, err := c.RemoveTorrent(ctx, t.Hash, deleteData)
 			if err != nil {
 				log.WithError(err).Fatalf("Failed removing torrent: %+v", t)
 				// dont remove from torrents file map, but prevent further operations on this torrent
@@ -381,7 +382,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 			log.WithError(err).Errorf("Failed determining whether to ignore: %+v", t)
 			delete(torrents, h)
 			continue
-		} else if ignore && !(config.Config.BypassIgnoreIfUnregistered && t.IsUnregistered()) {
+		} else if ignore && !(config.Config.BypassIgnoreIfUnregistered && t.IsUnregistered(ctx)) {
 			// torrent met ignore filter
 			log.Tracef("Ignoring torrent %s: %s", h, t.Name)
 			delete(torrents, h)
@@ -419,7 +420,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 		}
 
 		if isNotUnique {
-			if handled := handleNonUniqueTorrent(h, &t, isHardlinked); handled {
+			if handled := handleNonUniqueTorrent(ctx, h, &t, isHardlinked); handled {
 				// Torrent was handled (removed) in the function
 				continue
 			} else {
@@ -429,7 +430,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 			}
 		}
 
-		removeTorrent(h, &t)
+		removeTorrent(ctx, h, &t)
 	}
 
 	log.Info("========================================")
@@ -454,7 +455,7 @@ func removeEligibleTorrents(log *logrus.Entry, c client.Interface, torrents map[
 			continue
 		}
 
-		removeTorrent(h, &t)
+		removeTorrent(ctx, h, &t)
 		removedCandidates++
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -36,7 +36,7 @@ func retagEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.TagI
 	// iterate torrents
 	for h, t := range torrents {
 		// should we retag torrent and/or apply speed limit?
-		retagInfo, err := c.ShouldRetag(&t)
+		retagInfo, err := c.ShouldRetag(ctx, &t)
 		if err != nil {
 			// error while determining whether to evaluate tag rules
 			log.WithError(err).Errorf("Failed evaluating tag rules for: %+v", t)
@@ -147,7 +147,7 @@ func relabelEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.In
 	// iterate torrents
 	for h, t := range torrents {
 		// should we relabel torrent?
-		label, relabel, err := c.ShouldRelabel(&t)
+		label, relabel, err := c.ShouldRelabel(ctx, &t)
 		if err != nil {
 			// error while determining whether to relabel torrent
 			log.WithError(err).Errorf("Failed determining whether to relabel: %+v", t)
@@ -376,7 +376,7 @@ func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Int
 	candidates := make(map[string]config.Torrent)
 	for h, t := range torrents {
 		// should we ignore this torrent?
-		ignore, err := c.ShouldIgnore(&t)
+		ignore, err := c.ShouldIgnore(ctx, &t)
 		if err != nil {
 			// error while determining whether to ignore torrent
 			log.WithError(err).Errorf("Failed determining whether to ignore: %+v", t)
@@ -391,7 +391,7 @@ func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Int
 		}
 
 		// should we remove this torrent?
-		remove, err := c.ShouldRemove(&t)
+		remove, err := c.ShouldRemove(ctx, &t)
 		if err != nil {
 			log.WithError(err).Errorf("Failed determining whether to remove: %+v", t)
 			// dont do any further operations on this torrent, but keep in the torrent file map

--- a/cmd/orphan.go
+++ b/cmd/orphan.go
@@ -28,6 +28,8 @@ var orphanCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
 		// init core
 		if !initialized {
 			initCore(true)
@@ -81,14 +83,14 @@ var orphanCmd = &cobra.Command{
 		log.Infof("Initialized client %q, type: %s (%d trackers)", clientName, c.Type(), tracker.Loaded())
 
 		// connect to client
-		if err := c.Connect(); err != nil {
+		if err := c.Connect(ctx); err != nil {
 			log.WithError(err).Fatal("Failed connecting")
 		} else {
 			log.Debugf("Connected to client")
 		}
 
 		// retrieve torrents
-		torrents, err := c.GetTorrents()
+		torrents, err := c.GetTorrents(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed retrieving torrents")
 		} else {

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -21,6 +21,8 @@ var pauseCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+
 		// init core
 		if !initialized {
 			initCore(true)
@@ -79,7 +81,7 @@ var pauseCmd = &cobra.Command{
 		log.Infof("Initialized client %q, type: %s (%d trackers)", clientName, c.Type(), tracker.Loaded())
 
 		// connect to client
-		if err := c.Connect(); err != nil {
+		if err := c.Connect(ctx); err != nil {
 			log.WithError(err).Fatal("Failed connecting")
 		} else {
 			log.Debugf("Connected to client")
@@ -88,7 +90,7 @@ var pauseCmd = &cobra.Command{
 		// get free disk space (can/will be used by filters)
 		switch *clientType {
 		case "qbittorrent":
-			space, err := c.GetCurrentFreeSpace("")
+			space, err := c.GetCurrentFreeSpace(ctx, "")
 			if err != nil {
 				log.WithError(err).Error("Failed retrieving free-space")
 			} else {
@@ -98,7 +100,7 @@ var pauseCmd = &cobra.Command{
 
 		case "deluge":
 			if clientFreeSpacePath != nil {
-				space, err := c.GetCurrentFreeSpace(*clientFreeSpacePath)
+				space, err := c.GetCurrentFreeSpace(ctx, *clientFreeSpacePath)
 				if err != nil {
 					log.WithError(err).Errorf("Failed retrieving free-space for: %q", *clientFreeSpacePath)
 					os.Exit(1)
@@ -117,7 +119,7 @@ var pauseCmd = &cobra.Command{
 		}
 
 		// retrieve torrents
-		torrents, err := c.GetTorrents()
+		torrents, err := c.GetTorrents(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed retrieving torrents")
 		} else {
@@ -159,7 +161,7 @@ var pauseCmd = &cobra.Command{
 		if !flagDryRun {
 			if len(pauseList) > 0 {
 				log.Infof("Pausing %d torrent(s)...", len(pauseList))
-				if err := c.PauseTorrents(pauseList); err != nil {
+				if err := c.PauseTorrents(ctx, pauseList); err != nil {
 					log.WithError(err).Fatalf("Failed pausing torrents: %v", err)
 				}
 				log.Infof("Successfully paused %d torrent(s)", len(pauseList))

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -139,7 +139,7 @@ var pauseCmd = &cobra.Command{
 		// iterate through torrents
 		for _, t := range torrents {
 			// check if torrent should be ignored
-			if ignored, err := c.ShouldIgnore(&t); err != nil {
+			if ignored, err := c.ShouldIgnore(ctx, &t); err != nil {
 				log.WithError(err).Errorf("Failed checking ignore filters for torrent: %q", t.Name)
 				continue
 			} else if ignored {
@@ -148,7 +148,7 @@ var pauseCmd = &cobra.Command{
 			}
 
 			// check if torrent should be paused
-			if paused, err := c.CheckTorrentPause(&t); err != nil {
+			if paused, err := c.CheckTorrentPause(ctx, &t); err != nil {
 				log.WithError(err).Errorf("Failed checking pause filters for torrent: %q", t.Name)
 				continue
 			} else if paused {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 toolchain go1.24.2
 
 require (
+	github.com/autobrr/go-deluge v1.3.0
 	github.com/autobrr/go-qbittorrent v1.13.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bobesa/go-domain-util v0.0.0-20190911083921-4033b5f7dd89
@@ -12,7 +13,6 @@ require (
 	github.com/dlclark/regexp2 v1.11.5
 	github.com/dustin/go-humanize v1.0.1
 	github.com/expr-lang/expr v1.17.2
-	github.com/gdm85/go-libdeluge v0.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/knadh/koanf v1.5.0
 	github.com/lucperkins/rek v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/autobrr/go-qbittorrent v1.12.0 h1:TZoutIytmvnTNcj2FjuA2II4ouQsyxYr16H+EOwho5E=
-github.com/autobrr/go-qbittorrent v1.12.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
+github.com/autobrr/go-deluge v1.3.0 h1:c29FqwGdNJFIjGOQNuEn0uiIxoGxklbUmSJcKqGAdAI=
+github.com/autobrr/go-deluge v1.3.0/go.mod h1:ndiXT1eHWv/ATNk9TpE8GHIs8OSSUnsImt4Syk+y5LM=
 github.com/autobrr/go-qbittorrent v1.13.0 h1:cD/jSTnSRFozEiQNp6EkNm5GBizQubUav3vFw+v8g6k=
 github.com/autobrr/go-qbittorrent v1.13.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
@@ -77,8 +77,6 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/gdm85/go-libdeluge v0.6.0 h1:TCqzmABxup3l1yeWWW6ZIGoxgJZrrKB5aBF6z6BbVPg=
-github.com/gdm85/go-libdeluge v0.6.0/go.mod h1:y3CUYGywCSDOB32/IBLomtK+fU4+lfqIFWsnA/jBoeY=
 github.com/gdm85/go-rencode v0.1.8 h1:7+qxwoQWU1b1nMGcESOyoUR5dzPtRA6yLQpKn7uXmnI=
 github.com/gdm85/go-rencode v0.1.8/go.mod h1:0dr3BuaKzeseY1of6o1KRTGB/Oo7eio+YEyz8KDp5+s=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/client/deluge.go
+++ b/pkg/client/deluge.go
@@ -279,8 +279,8 @@ func (c *Deluge) GetFreeSpace() float64 {
 
 /* Filters */
 
-func (c *Deluge) ShouldIgnore(t *config.Torrent) (bool, error) {
-	match, err := expression.CheckTorrentSingleMatch(t, c.exp.Ignores)
+func (c *Deluge) ShouldIgnore(ctx context.Context, t *config.Torrent) (bool, error) {
+	match, err := expression.CheckTorrentSingleMatch(ctx, t, c.exp.Ignores)
 	if err != nil {
 		return true, fmt.Errorf("check ignore expression: %v: %w", t.Hash, err)
 	}
@@ -288,8 +288,8 @@ func (c *Deluge) ShouldIgnore(t *config.Torrent) (bool, error) {
 	return match, nil
 }
 
-func (c *Deluge) ShouldRemove(t *config.Torrent) (bool, error) {
-	match, err := expression.CheckTorrentSingleMatch(t, c.exp.Removes)
+func (c *Deluge) ShouldRemove(ctx context.Context, t *config.Torrent) (bool, error) {
+	match, err := expression.CheckTorrentSingleMatch(ctx, t, c.exp.Removes)
 	if err != nil {
 		return false, fmt.Errorf("check remove expression: %v: %w", t.Hash, err)
 	}
@@ -297,10 +297,10 @@ func (c *Deluge) ShouldRemove(t *config.Torrent) (bool, error) {
 	return match, nil
 }
 
-func (c *Deluge) ShouldRelabel(t *config.Torrent) (string, bool, error) {
+func (c *Deluge) ShouldRelabel(ctx context.Context, t *config.Torrent) (string, bool, error) {
 	for _, label := range c.exp.Labels {
 		// check update
-		match, err := expression.CheckTorrentAllMatch(t, label.Updates)
+		match, err := expression.CheckTorrentAllMatch(ctx, t, label.Updates)
 		if err != nil {
 			return "", false, fmt.Errorf("check update expression: %v: %w", t.Hash, err)
 		} else if !match {
@@ -341,8 +341,8 @@ func (c *Deluge) SetUploadLimit(ctx context.Context, hash string, limit int64) e
 	return nil
 }
 
-func (c *Deluge) CheckTorrentPause(t *config.Torrent) (bool, error) {
-	match, err := expression.CheckTorrentSingleMatch(t, c.exp.Pauses)
+func (c *Deluge) CheckTorrentPause(ctx context.Context, t *config.Torrent) (bool, error) {
+	match, err := expression.CheckTorrentSingleMatch(ctx, t, c.exp.Pauses)
 	if err != nil {
 		return false, fmt.Errorf("check pause expression: %v: %w", t.Hash, err)
 	}

--- a/pkg/client/deluge.go
+++ b/pkg/client/deluge.go
@@ -1,12 +1,13 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"time"
 
+	delugeclient "github.com/autobrr/go-deluge"
 	"github.com/dustin/go-humanize"
-	delugeclient "github.com/gdm85/go-libdeluge"
 	"github.com/sirupsen/logrus"
 
 	"github.com/autobrr/tqm/pkg/config"
@@ -80,16 +81,16 @@ func (c *Deluge) Type() string {
 	return c.clientType
 }
 
-func (c *Deluge) Connect() error {
+func (c *Deluge) Connect(ctx context.Context) error {
 	var err error
 
 	// connect to deluge daemon
 	c.log.Tracef("Connecting to %s:%d", *c.Host, *c.Port)
 
 	if c.V2 {
-		err = c.client2.Connect()
+		err = c.client2.Connect(ctx)
 	} else {
-		err = c.client1.Connect()
+		err = c.client1.Connect(ctx)
 
 	}
 
@@ -101,9 +102,9 @@ func (c *Deluge) Connect() error {
 	var lc *delugeclient.LabelPlugin
 
 	if c.V2 {
-		lc, err = c.client2.LabelPlugin()
+		lc, err = c.client2.LabelPlugin(ctx)
 	} else {
-		lc, err = c.client1.LabelPlugin()
+		lc, err = c.client1.LabelPlugin(ctx)
 	}
 
 	if err != nil {
@@ -111,7 +112,7 @@ func (c *Deluge) Connect() error {
 	}
 
 	// retrieve daemon version
-	daemonVersion, err := lc.DaemonVersion()
+	daemonVersion, err := lc.DaemonVersion(ctx)
 	if err != nil {
 		return fmt.Errorf("get daemon version: %w", err)
 	}
@@ -121,7 +122,7 @@ func (c *Deluge) Connect() error {
 	return nil
 }
 
-func (c *Deluge) LoadLabelPathMap() error {
+func (c *Deluge) LoadLabelPathMap(context.Context) error {
 	// @TODO: implement
 	return nil
 }
@@ -130,10 +131,10 @@ func (c *Deluge) LabelPathMap() map[string]string {
 	return nil
 }
 
-func (c *Deluge) GetTorrents() (map[string]config.Torrent, error) {
+func (c *Deluge) GetTorrents(ctx context.Context) (map[string]config.Torrent, error) {
 	// retrieve torrents from client
 	c.log.Tracef("Retrieving torrents...")
-	t, err := c.client.TorrentsStatus(delugeclient.StateUnspecified, nil)
+	t, err := c.client.TorrentsStatus(ctx, delugeclient.StateUnspecified, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get torrents: %w", err)
 	}
@@ -202,16 +203,16 @@ func (c *Deluge) GetTorrents() (map[string]config.Torrent, error) {
 	return torrents, nil
 }
 
-func (c *Deluge) RemoveTorrent(hash string, deleteData bool) (bool, error) {
+func (c *Deluge) RemoveTorrent(ctx context.Context, hash string, deleteData bool) (bool, error) {
 	// pause torrent
-	if err := c.client.PauseTorrents(hash); err != nil {
+	if err := c.client.PauseTorrents(ctx, hash); err != nil {
 		return false, fmt.Errorf("pause torrent: %v: %w", hash, err)
 	}
 
 	time.Sleep(1 * time.Second)
 
 	// resume torrent
-	if err := c.client.ResumeTorrents(hash); err != nil {
+	if err := c.client.ResumeTorrents(ctx, hash); err != nil {
 		return false, fmt.Errorf("resume torrent: %v: %w", hash, err)
 	}
 
@@ -219,7 +220,7 @@ func (c *Deluge) RemoveTorrent(hash string, deleteData bool) (bool, error) {
 	time.Sleep(2 * time.Second)
 
 	// re-announce torrent
-	if err := c.client.ForceReannounce([]string{hash}); err != nil {
+	if err := c.client.ForceReannounce(ctx, []string{hash}); err != nil {
 		return false, fmt.Errorf("re-announce torrent: %v: %w", hash, err)
 	}
 
@@ -227,7 +228,7 @@ func (c *Deluge) RemoveTorrent(hash string, deleteData bool) (bool, error) {
 	time.Sleep(2 * time.Second)
 
 	// remove
-	if ok, err := c.client.RemoveTorrent(hash, deleteData); err != nil {
+	if ok, err := c.client.RemoveTorrent(ctx, hash, deleteData); err != nil {
 		return false, fmt.Errorf("remove torrent: %v: %w", hash, err)
 	} else if !ok {
 		return false, fmt.Errorf("remove torrent: %v", hash)
@@ -236,27 +237,27 @@ func (c *Deluge) RemoveTorrent(hash string, deleteData bool) (bool, error) {
 	return true, nil
 }
 
-func (c *Deluge) SetTorrentLabel(hash string, label string, hardlink bool) error {
+func (c *Deluge) SetTorrentLabel(ctx context.Context, hash string, label string, hardlink bool) error {
 	// hardlink behaviour currently not tested for deluge
 	if hardlink {
 		return fmt.Errorf("hardlink relabeling not supported for deluge (yet)")
 	}
 
 	// set label
-	if err := c.client.SetTorrentLabel(hash, label); err != nil {
+	if err := c.client.SetTorrentLabel(ctx, hash, label); err != nil {
 		return fmt.Errorf("set torrent label: %v: %w", label, err)
 	}
 
 	return nil
 }
 
-func (c *Deluge) GetCurrentFreeSpace(path string) (int64, error) {
+func (c *Deluge) GetCurrentFreeSpace(ctx context.Context, path string) (int64, error) {
 	if path == "" {
 		return 0, fmt.Errorf("free_space_path is not set for deluge")
 	}
 
 	// get free disk space
-	space, err := c.client.GetFreeSpace(path)
+	space, err := c.client.GetFreeSpace(ctx, path)
 	if err != nil {
 		return 0, fmt.Errorf("get free disk space: %v: %w", path, err)
 	}
@@ -313,7 +314,7 @@ func (c *Deluge) ShouldRelabel(t *config.Torrent) (string, bool, error) {
 	return "", false, nil
 }
 
-func (c *Deluge) SetUploadLimit(hash string, limit int64) error {
+func (c *Deluge) SetUploadLimit(ctx context.Context, hash string, limit int64) error {
 	var uploadSpeed int
 	if limit == -1 {
 		uploadSpeed = -1
@@ -327,9 +328,9 @@ func (c *Deluge) SetUploadLimit(hash string, limit int64) error {
 
 	var err error
 	if c.V2 {
-		err = c.client2.SetTorrentOptions(hash, opts)
+		err = c.client2.SetTorrentOptions(ctx, hash, opts)
 	} else {
-		err = c.client1.SetTorrentOptions(hash, opts)
+		err = c.client1.SetTorrentOptions(ctx, hash, opts)
 	}
 
 	if err != nil {
@@ -349,12 +350,12 @@ func (c *Deluge) CheckTorrentPause(t *config.Torrent) (bool, error) {
 	return match, nil
 }
 
-func (c *Deluge) PauseTorrents(hashes []string) error {
+func (c *Deluge) PauseTorrents(ctx context.Context, hashes []string) error {
 	var err error
 	if c.V2 {
-		err = c.client2.PauseTorrents(hashes...)
+		err = c.client2.PauseTorrents(ctx, hashes...)
 	} else {
-		err = c.client1.PauseTorrents(hashes...)
+		err = c.client1.PauseTorrents(ctx, hashes...)
 	}
 
 	if err != nil {

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/autobrr/tqm/pkg/config"
 )
 
@@ -19,10 +20,10 @@ type Interface interface {
 
 	SetUploadLimit(ctx context.Context, hash string, limit int64) error
 
-	ShouldIgnore(*config.Torrent) (bool, error)
-	ShouldRemove(*config.Torrent) (bool, error)
-	CheckTorrentPause(*config.Torrent) (bool, error)
-	ShouldRelabel(*config.Torrent) (string, bool, error)
+	ShouldIgnore(ctx context.Context, t *config.Torrent) (bool, error)
+	ShouldRemove(ctx context.Context, t *config.Torrent) (bool, error)
+	CheckTorrentPause(ctx context.Context, t *config.Torrent) (bool, error)
+	ShouldRelabel(ctx context.Context, t *config.Torrent) (string, bool, error)
 
 	PauseTorrents(ctx context.Context, hashes []string) error
 }

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -1,27 +1,28 @@
 package client
 
 import (
+	"context"
 	"github.com/autobrr/tqm/pkg/config"
 )
 
 type Interface interface {
 	Type() string
-	Connect() error
-	GetTorrents() (map[string]config.Torrent, error)
-	RemoveTorrent(string, bool) (bool, error)
-	SetTorrentLabel(hash string, label string, hardlink bool) error
-	GetCurrentFreeSpace(string) (int64, error)
+	Connect(ctx context.Context) error
+	GetTorrents(ctx context.Context) (map[string]config.Torrent, error)
+	RemoveTorrent(ctx context.Context, hash string, deleteData bool) (bool, error)
+	SetTorrentLabel(ctx context.Context, hash string, label string, hardlink bool) error
+	GetCurrentFreeSpace(ctx context.Context, path string) (int64, error)
 	AddFreeSpace(int64)
 	GetFreeSpace() float64
-	LoadLabelPathMap() error
+	LoadLabelPathMap(ctx context.Context) error
 	LabelPathMap() map[string]string
 
-	SetUploadLimit(hash string, limit int64) error
+	SetUploadLimit(ctx context.Context, hash string, limit int64) error
 
 	ShouldIgnore(*config.Torrent) (bool, error)
 	ShouldRemove(*config.Torrent) (bool, error)
 	CheckTorrentPause(*config.Torrent) (bool, error)
 	ShouldRelabel(*config.Torrent) (string, bool, error)
 
-	PauseTorrents([]string) error
+	PauseTorrents(ctx context.Context, hashes []string) error
 }

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -390,8 +390,8 @@ func (c *QBittorrent) GetFreeSpace() float64 {
 
 /* Filters */
 
-func (c *QBittorrent) ShouldIgnore(t *config.Torrent) (bool, error) {
-	match, err := expression.CheckTorrentSingleMatch(t, c.exp.Ignores)
+func (c *QBittorrent) ShouldIgnore(ctx context.Context, t *config.Torrent) (bool, error) {
+	match, err := expression.CheckTorrentSingleMatch(ctx, t, c.exp.Ignores)
 	if err != nil {
 		return true, fmt.Errorf("check ignore expression: %v: %w", t.Hash, err)
 	}
@@ -399,8 +399,8 @@ func (c *QBittorrent) ShouldIgnore(t *config.Torrent) (bool, error) {
 	return match, nil
 }
 
-func (c *QBittorrent) ShouldRemove(t *config.Torrent) (bool, error) {
-	match, err := expression.CheckTorrentSingleMatch(t, c.exp.Removes)
+func (c *QBittorrent) ShouldRemove(ctx context.Context, t *config.Torrent) (bool, error) {
+	match, err := expression.CheckTorrentSingleMatch(ctx, t, c.exp.Removes)
 	if err != nil {
 		return false, fmt.Errorf("check remove expression: %v: %w", t.Hash, err)
 	}
@@ -408,10 +408,10 @@ func (c *QBittorrent) ShouldRemove(t *config.Torrent) (bool, error) {
 	return match, nil
 }
 
-func (c *QBittorrent) ShouldRelabel(t *config.Torrent) (string, bool, error) {
+func (c *QBittorrent) ShouldRelabel(ctx context.Context, t *config.Torrent) (string, bool, error) {
 	for _, label := range c.exp.Labels {
 		// check update
-		match, err := expression.CheckTorrentAllMatch(t, label.Updates)
+		match, err := expression.CheckTorrentAllMatch(ctx, t, label.Updates)
 		if err != nil {
 			return "", false, fmt.Errorf("check update expression: %v: %w", t.Hash, err)
 		} else if !match {
@@ -425,8 +425,8 @@ func (c *QBittorrent) ShouldRelabel(t *config.Torrent) (string, bool, error) {
 	return "", false, nil
 }
 
-func (c *QBittorrent) CheckTorrentPause(t *config.Torrent) (bool, error) {
-	match, err := expression.CheckTorrentSingleMatch(t, c.exp.Pauses)
+func (c *QBittorrent) CheckTorrentPause(ctx context.Context, t *config.Torrent) (bool, error) {
+	match, err := expression.CheckTorrentSingleMatch(ctx, t, c.exp.Pauses)
 	if err != nil {
 		return false, fmt.Errorf("check pause expression: %v: %w", t.Hash, err)
 	}
@@ -441,13 +441,13 @@ func (c *QBittorrent) PauseTorrents(ctx context.Context, hashes []string) error 
 	return nil
 }
 
-func (c *QBittorrent) ShouldRetag(t *config.Torrent) (RetagInfo, error) {
+func (c *QBittorrent) ShouldRetag(ctx context.Context, t *config.Torrent) (RetagInfo, error) {
 	var retagInfo = RetagInfo{}
 	var uploadLimitSet = false
 
 	for _, tagRule := range c.exp.Tags {
 		// check update
-		match, err := expression.CheckTorrentAllMatch(t, tagRule.Updates)
+		match, err := expression.CheckTorrentAllMatch(ctx, t, tagRule.Updates)
 		if err != nil {
 			return RetagInfo{}, fmt.Errorf("check update expression for tag %s on torrent %v: %w", tagRule.Name, t.Hash, err)
 		}

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -85,7 +85,7 @@ func (c *QBittorrent) Type() string {
 	return c.clientType
 }
 
-func (c *QBittorrent) Connect() error {
+func (c *QBittorrent) Connect(context.Context) error {
 	// login
 	if err := c.client.Login(); err != nil {
 		return fmt.Errorf("login: %w", err)
@@ -105,13 +105,13 @@ func (c *QBittorrent) Connect() error {
 	return nil
 }
 
-func (c *QBittorrent) LoadLabelPathMap() error {
-	p, err := c.client.GetAppPreferences()
+func (c *QBittorrent) LoadLabelPathMap(ctx context.Context) error {
+	p, err := c.client.GetAppPreferencesCtx(ctx)
 	if err != nil {
 		return fmt.Errorf("get app preferences: %w", err)
 	}
 
-	cats, err := c.client.GetCategories()
+	cats, err := c.client.GetCategoriesCtx(ctx)
 	if err != nil {
 		return fmt.Errorf("get categories: %w", err)
 	}
@@ -138,10 +138,10 @@ func (c *QBittorrent) LabelPathMap() map[string]string {
 	return c.labelPathMap
 }
 
-func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
+func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torrent, error) {
 	// retrieve torrents from client
 	c.log.Tracef("Retrieving torrents...")
-	t, err := c.client.GetTorrents(qbit.TorrentFilterOptions{IncludeTrackers: true})
+	t, err := c.client.GetTorrentsCtx(ctx, qbit.TorrentFilterOptions{IncludeTrackers: true})
 	if err != nil {
 		return nil, fmt.Errorf("get torrents: %w", err)
 	}
@@ -152,12 +152,12 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 	for _, t := range t {
 		// get additional torrent details
 		//td, err := c.client.Torrent.GetProperties(t.Hash)
-		td, err := c.client.GetTorrentProperties(t.Hash)
+		td, err := c.client.GetTorrentPropertiesCtx(ctx, t.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("get torrent properties: %v: %w", t.Hash, err)
 		}
 
-		tf, err := c.client.GetFilesInformation(t.Hash)
+		tf, err := c.client.GetFilesInformationCtx(ctx, t.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("get torrent files: %v: %w", t.Hash, err)
 		}
@@ -172,7 +172,7 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 
 		// in qBittorrent v5.1+ we can use includeTrackers to populate trackers, but in older versions we need to fetch trackers per torrent
 		if len(t.Trackers) == 0 {
-			ts, err := c.client.GetTorrentTrackers(t.Hash)
+			ts, err := c.client.GetTorrentTrackersCtx(ctx, t.Hash)
 			if err != nil {
 				return nil, fmt.Errorf("get torrent trackers: %v: %w", t.Hash, err)
 			}
@@ -258,23 +258,23 @@ func (c *QBittorrent) GetTorrents() (map[string]config.Torrent, error) {
 	return torrents, nil
 }
 
-func (c *QBittorrent) RemoveTorrent(hash string, deleteData bool) (bool, error) {
+func (c *QBittorrent) RemoveTorrent(ctx context.Context, hash string, deleteData bool) (bool, error) {
 	// pause torrent
-	if err := c.client.Pause([]string{hash}); err != nil {
+	if err := c.client.PauseCtx(ctx, []string{hash}); err != nil {
 		return false, fmt.Errorf("pause torrent: %v: %w", hash, err)
 	}
 
 	time.Sleep(1 * time.Second)
 
 	// resume torrent
-	if err := c.client.Resume([]string{hash}); err != nil {
+	if err := c.client.ResumeCtx(ctx, []string{hash}); err != nil {
 		return false, fmt.Errorf("resume torrent: %v: %w", hash, err)
 	}
 
 	// sleep before re-announcing torrent
 	time.Sleep(2 * time.Second)
 
-	if err := c.client.ReAnnounceTorrents([]string{hash}); err != nil {
+	if err := c.client.ReAnnounceTorrentsCtx(ctx, []string{hash}); err != nil {
 		return false, fmt.Errorf("re-announce torrent: %v: %w", hash, err)
 	}
 
@@ -282,14 +282,14 @@ func (c *QBittorrent) RemoveTorrent(hash string, deleteData bool) (bool, error) 
 	time.Sleep(2 * time.Second)
 
 	// remove
-	if err := c.client.DeleteTorrents([]string{hash}, deleteData); err != nil {
+	if err := c.client.DeleteTorrentsCtx(ctx, []string{hash}, deleteData); err != nil {
 		return false, fmt.Errorf("delete torrent: %v: %w", hash, err)
 	}
 
 	return true, nil
 }
 
-func (c *QBittorrent) SetTorrentLabel(hash string, label string, hardlink bool) error {
+func (c *QBittorrent) SetTorrentLabel(ctx context.Context, hash string, label string, hardlink bool) error {
 	if hardlink {
 		// get label path
 		lp := c.labelPathMap[label]
@@ -298,14 +298,14 @@ func (c *QBittorrent) SetTorrentLabel(hash string, label string, hardlink bool) 
 		}
 
 		// get torrent details
-		td, err := c.client.GetTorrentProperties(hash)
+		td, err := c.client.GetTorrentPropertiesCtx(ctx, hash)
 		if err != nil {
 			return fmt.Errorf("get torrent properties: %w", err)
 		}
 
 		if filepath.Clean(td.SavePath) != filepath.Clean(lp) {
 			// get torrent files
-			tf, err := c.client.GetFilesInformation(hash)
+			tf, err := c.client.GetFilesInformationCtx(ctx, hash)
 			if err != nil {
 				return fmt.Errorf("get torrent files: %w", err)
 			}
@@ -333,22 +333,22 @@ func (c *QBittorrent) SetTorrentLabel(hash string, label string, hardlink bool) 
 		// qbit force moves the files, overwriting existing files
 		// manually settings location, and then setting category works
 		// and causes qbit to recheck instead of move
-		if err := c.client.SetAutoManagement([]string{hash}, false); err != nil {
+		if err := c.client.SetAutoManagementCtx(ctx, []string{hash}, false); err != nil {
 			return fmt.Errorf("set automatic management: %w", err)
 		}
-		if err := c.client.SetLocation([]string{hash}, lp); err != nil {
+		if err := c.client.SetLocationCtx(ctx, []string{hash}, lp); err != nil {
 			return fmt.Errorf("set location: %w", err)
 		}
 	}
 
 	// set label
-	if err := c.client.SetCategory([]string{hash}, label); err != nil {
+	if err := c.client.SetCategoryCtx(ctx, []string{hash}, label); err != nil {
 		return fmt.Errorf("set torrent label: %v: %w", label, err)
 	}
 
 	// enable autotmm
 	if c.EnableAutoTmmAfterRelabel && !hardlink {
-		if err := c.client.SetAutoManagement([]string{hash}, true); err != nil {
+		if err := c.client.SetAutoManagementCtx(ctx, []string{hash}, true); err != nil {
 			return fmt.Errorf("enable autotmm: %w", err)
 		}
 	}
@@ -356,9 +356,7 @@ func (c *QBittorrent) SetTorrentLabel(hash string, label string, hardlink bool) 
 	return nil
 }
 
-func (c *QBittorrent) SetUploadLimit(hash string, limit int64) error {
-
-	ctx := context.Background()
+func (c *QBittorrent) SetUploadLimit(ctx context.Context, hash string, limit int64) error {
 	err := c.client.SetTorrentUploadLimitCtx(ctx, []string{hash}, limit)
 	if err != nil {
 		return fmt.Errorf("set upload limit for %s: %w", hash, err)
@@ -368,9 +366,9 @@ func (c *QBittorrent) SetUploadLimit(hash string, limit int64) error {
 	return nil
 }
 
-func (c *QBittorrent) GetCurrentFreeSpace(path string) (int64, error) {
+func (c *QBittorrent) GetCurrentFreeSpace(ctx context.Context, path string) (int64, error) {
 	// get current main stats
-	data, err := c.client.SyncMainDataCtx(context.Background(), 0)
+	data, err := c.client.SyncMainDataCtx(ctx, 0)
 	if err != nil {
 		return 0, fmt.Errorf("get main data: %w", err)
 	}
@@ -436,8 +434,8 @@ func (c *QBittorrent) CheckTorrentPause(t *config.Torrent) (bool, error) {
 	return match, nil
 }
 
-func (c *QBittorrent) PauseTorrents(hashes []string) error {
-	if err := c.client.Pause(hashes); err != nil {
+func (c *QBittorrent) PauseTorrents(ctx context.Context, hashes []string) error {
+	if err := c.client.PauseCtx(ctx, hashes); err != nil {
 		return fmt.Errorf("pause torrents: %v: %w", hashes, err)
 	}
 	return nil
@@ -478,48 +476,48 @@ func (c *QBittorrent) ShouldRetag(t *config.Torrent) (RetagInfo, error) {
 	return retagInfo, nil
 }
 
-func (c *QBittorrent) AddTags(hash string, tags []string) error {
+func (c *QBittorrent) AddTags(ctx context.Context, hash string, tags []string) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	if err := c.client.AddTags([]string{hash}, strings.Join(tags, ",")); err != nil {
+	if err := c.client.AddTagsCtx(ctx, []string{hash}, strings.Join(tags, ",")); err != nil {
 		return fmt.Errorf("add torrent tags: %v: %w", tags, err)
 	}
 
 	return nil
 }
 
-func (c *QBittorrent) RemoveTags(hash string, tags []string) error {
+func (c *QBittorrent) RemoveTags(ctx context.Context, hash string, tags []string) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	if err := c.client.RemoveTags([]string{hash}, strings.Join(tags, ",")); err != nil {
+	if err := c.client.RemoveTagsCtx(ctx, []string{hash}, strings.Join(tags, ",")); err != nil {
 		return fmt.Errorf("add torrent tags: %v: %w", tags, err)
 	}
 
 	return nil
 }
 
-func (c *QBittorrent) CreateTags(tags []string) error {
+func (c *QBittorrent) CreateTags(ctx context.Context, tags []string) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	if err := c.client.CreateTags(tags); err != nil {
+	if err := c.client.CreateTagsCtx(ctx, tags); err != nil {
 		return fmt.Errorf("create torrent tags: %v: %w", tags, err)
 	}
 
 	return nil
 }
 
-func (c *QBittorrent) DeleteTags(tags []string) error {
+func (c *QBittorrent) DeleteTags(ctx context.Context, tags []string) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	if err := c.client.DeleteTags(tags); err != nil {
+	if err := c.client.DeleteTagsCtx(ctx, tags); err != nil {
 		return fmt.Errorf("delete torrent tags: %v: %w", tags, err)
 	}
 

--- a/pkg/client/tagInterface.go
+++ b/pkg/client/tagInterface.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"github.com/autobrr/tqm/pkg/config"
 )
 
@@ -14,8 +15,8 @@ type TagInterface interface {
 	Interface
 
 	ShouldRetag(*config.Torrent) (RetagInfo, error)
-	AddTags(string, []string) error
-	RemoveTags(string, []string) error
-	CreateTags([]string) error
-	DeleteTags([]string) error
+	AddTags(ctx context.Context, hash string, tags []string) error
+	RemoveTags(ctx context.Context, hash string, tags []string) error
+	CreateTags(ctx context.Context, tags []string) error
+	DeleteTags(ctx context.Context, tags []string) error
 }

--- a/pkg/client/tagInterface.go
+++ b/pkg/client/tagInterface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/autobrr/tqm/pkg/config"
 )
 
@@ -14,7 +15,7 @@ type RetagInfo struct {
 type TagInterface interface {
 	Interface
 
-	ShouldRetag(*config.Torrent) (RetagInfo, error)
+	ShouldRetag(ctx context.Context, t *config.Torrent) (RetagInfo, error)
 	AddTags(ctx context.Context, hash string, tags []string) error
 	RemoveTags(ctx context.Context, hash string, tags []string) error
 	CreateTags(ctx context.Context, tags []string) error

--- a/pkg/config/torrent.go
+++ b/pkg/config/torrent.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"math"
 	"os"
 	"strings"
@@ -182,7 +183,7 @@ func InitializeTrackerStatuses(perTrackerOverrides map[string][]string) {
 	}
 }
 
-func (t *Torrent) IsUnregistered() bool {
+func (t *Torrent) IsUnregistered(ctx context.Context) bool {
 	if t.IsTrackerDown() {
 		return false
 	}
@@ -222,7 +223,7 @@ func (t *Torrent) IsUnregistered() bool {
 			Comment:         t.Comment,
 		}
 
-		if err, ur := tr.IsUnregistered(tt); err == nil {
+		if err, ur := tr.IsUnregistered(ctx, tt); err == nil {
 			return ur
 		}
 	}

--- a/pkg/expression/check.go
+++ b/pkg/expression/check.go
@@ -1,6 +1,7 @@
 package expression
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/expr-lang/expr"
@@ -9,9 +10,11 @@ import (
 	"github.com/autobrr/tqm/pkg/config"
 )
 
-func CheckTorrentSingleMatch(t *config.Torrent, exp []*vm.Program) (bool, error) {
+func CheckTorrentSingleMatch(ctx context.Context, t *config.Torrent, exp []*vm.Program) (bool, error) {
+	env := &evalContext{Torrent: t, ctx: ctx}
+
 	for _, expression := range exp {
-		result, err := expr.Run(expression, t)
+		result, err := expr.Run(expression, env)
 		if err != nil {
 			return false, fmt.Errorf("check expression: %w", err)
 		}
@@ -29,9 +32,11 @@ func CheckTorrentSingleMatch(t *config.Torrent, exp []*vm.Program) (bool, error)
 	return false, nil
 }
 
-func CheckTorrentAllMatch(t *config.Torrent, exp []*vm.Program) (bool, error) {
+func CheckTorrentAllMatch(ctx context.Context, t *config.Torrent, exp []*vm.Program) (bool, error) {
+	env := &evalContext{Torrent: t, ctx: ctx}
+
 	for _, expression := range exp {
-		result, err := expr.Run(expression, t)
+		result, err := expr.Run(expression, env)
 		if err != nil {
 			return false, fmt.Errorf("check expression: %w", err)
 		}

--- a/pkg/expression/compile.go
+++ b/pkg/expression/compile.go
@@ -1,6 +1,7 @@
 package expression
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/expr-lang/expr"
@@ -9,8 +10,69 @@ import (
 	"github.com/autobrr/tqm/pkg/regex"
 )
 
+type evalContext struct {
+	*config.Torrent
+	ctx context.Context
+}
+
+func (e *evalContext) IsUnregistered() bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.IsUnregistered(e.ctx)
+}
+
+func (e *evalContext) IsTrackerDown() bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.IsTrackerDown()
+}
+
+func (e *evalContext) HasAllTags(tags ...string) bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.HasAllTags(tags...)
+}
+
+func (e *evalContext) HasAnyTag(tags ...string) bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.HasAnyTag(tags...)
+}
+
+func (e *evalContext) HasMissingFiles() bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.HasMissingFiles()
+}
+
+func (e *evalContext) RegexMatch(pattern string) bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.RegexMatch(pattern)
+}
+
+func (e *evalContext) RegexMatchAny(patternsStr string) bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.RegexMatchAny(patternsStr)
+}
+
+func (e *evalContext) RegexMatchAll(patternsStr string) bool {
+	if e.Torrent == nil {
+		return false
+	}
+	return e.Torrent.RegexMatchAll(patternsStr)
+}
+
 func Compile(filter *config.FilterConfiguration) (*Expressions, error) {
-	exprEnv := &config.Torrent{}
+	exprEnv := &evalContext{}
 	exp := new(Expressions)
 
 	// validate all regex patterns in expressions

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,7 +43,7 @@ func (c *BHD) Check(host string) bool {
 	return strings.Contains(host, "beyond-hd.me")
 }
 
-func (c *BHD) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	type Request struct {
 		Hash   string `json:"info_hash"`
 		Action string `json:"action"`
@@ -68,7 +69,7 @@ func (c *BHD) IsUnregistered(torrent *Torrent) (error, bool) {
 	}
 
 	// send request
-	resp, err := rek.Post(url, rek.Client(c.http), rek.Json(payload))
+	resp, err := rek.Post(url, rek.Client(c.http), rek.Json(payload), rek.Context(ctx))
 	if err != nil {
 		c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
 		return fmt.Errorf("bhd: request search: %w", err), false
@@ -93,6 +94,6 @@ func (c *BHD) IsUnregistered(torrent *Torrent) (error, bool) {
 	return nil, b.TotalResults < 1
 }
 
-func (c *BHD) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *BHD) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/btn.go
+++ b/pkg/tracker/btn.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -60,7 +61,7 @@ func (c *BTN) extractTorrentID(comment string) (string, error) {
 	return matches[1], nil
 }
 
-func (c *BTN) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *BTN) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	if !strings.EqualFold(torrent.TrackerName, "landof.tv") || torrent.Comment == "" {
 		return nil, false
 	}
@@ -165,6 +166,6 @@ func (c *BTN) IsUnregistered(torrent *Torrent) (error, bool) {
 	return nil, true
 }
 
-func (c *BTN) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *BTN) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/hdb.go
+++ b/pkg/tracker/hdb.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -43,7 +44,7 @@ func (c *HDB) Check(host string) bool {
 	return strings.Contains(host, "hdbits.org")
 }
 
-func (c *HDB) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *HDB) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	//c.log.Infof("Checking HDB torrent: %s", torrent.Name)
 
 	type Request struct {
@@ -75,6 +76,7 @@ func (c *HDB) IsUnregistered(torrent *Torrent) (error, bool) {
 	resp, err := rek.Post("https://hdbits.org/api/torrents",
 		rek.Client(c.http),
 		rek.Json(reqBody),
+		rek.Context(ctx),
 	)
 	if err != nil {
 		if resp == nil {
@@ -104,6 +106,6 @@ func (c *HDB) IsUnregistered(torrent *Torrent) (error, bool) {
 	return nil, b.Status == 0 && len(b.Data) == 0
 }
 
-func (c *HDB) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *HDB) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/interface.go
+++ b/pkg/tracker/interface.go
@@ -1,8 +1,10 @@
 package tracker
 
+import "context"
+
 type Interface interface {
 	Name() string
-	Check(string) bool
-	IsUnregistered(torrent *Torrent) (error, bool)
+	Check(host string) bool
+	IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool)
 	IsTrackerDown(torrent *Torrent) (error, bool)
 }

--- a/pkg/tracker/ops.go
+++ b/pkg/tracker/ops.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,7 +43,7 @@ func (c *OPS) Check(host string) bool {
 	return strings.Contains(host, "opsfet.ch")
 }
 
-func (c *OPS) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *OPS) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	//c.log.Infof("Checking OPS torrent: %s", torrent.Name)
 
 	type Response struct {
@@ -64,6 +65,7 @@ func (c *OPS) IsUnregistered(torrent *Torrent) (error, bool) {
 		rek.Headers(map[string]string{
 			"Authorization": fmt.Sprintf("token %s", c.cfg.Key),
 		}),
+		rek.Context(ctx),
 	)
 	if err != nil {
 		if resp == nil {
@@ -91,6 +93,6 @@ func (c *OPS) IsUnregistered(torrent *Torrent) (error, bool) {
 	return nil, b.Status == "failure" && b.Error == "bad parameters"
 }
 
-func (c *OPS) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *OPS) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/ptp.go
+++ b/pkg/tracker/ptp.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,7 +50,7 @@ func (c *PTP) Check(host string) bool {
 	return strings.Contains(host, "passthepopcorn.me")
 }
 
-func (c *PTP) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *PTP) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	type Response struct {
 		Result        string `json:"Result"`
 		ResultDetails string `json:"ResultDetails"`
@@ -64,7 +65,7 @@ func (c *PTP) IsUnregistered(torrent *Torrent) (error, bool) {
 	}
 
 	// send request
-	resp, err := rek.Get(reqURL, rek.Client(c.http), rek.Headers(c.headers))
+	resp, err := rek.Get(reqURL, rek.Client(c.http), rek.Headers(c.headers), rek.Context(ctx))
 	if err != nil {
 		c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
 		return fmt.Errorf("ptp: request search: %w", err), false
@@ -89,6 +90,6 @@ func (c *PTP) IsUnregistered(torrent *Torrent) (error, bool) {
 	return nil, b.Result == "ERROR" && b.ResultDetails == "Unregistered Torrent"
 }
 
-func (c *PTP) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *PTP) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/red.go
+++ b/pkg/tracker/red.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,7 +43,7 @@ func (c *RED) Check(host string) bool {
 	return strings.Contains(host, "flacsfor.me")
 }
 
-func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *RED) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	//c.log.Infof("Checking RED torrent: %s", torrent.Name)
 
 	type Response struct {
@@ -66,6 +67,7 @@ func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
 		rek.Headers(map[string]string{
 			"Authorization": c.cfg.Key,
 		}),
+		rek.Context(ctx),
 	)
 	if err != nil {
 		if resp == nil {
@@ -93,6 +95,6 @@ func (c *RED) IsUnregistered(torrent *Torrent) (error, bool) {
 	return nil, b.Status == "failure" && b.Error == "bad hash parameter"
 }
 
-func (c *RED) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *RED) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/unit3d.go
+++ b/pkg/tracker/unit3d.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -69,7 +70,7 @@ func (c *UNIT3D) extractTorrentID(comment string) (string, error) {
 	return matches[1], nil
 }
 
-func (c *UNIT3D) IsUnregistered(torrent *Torrent) (error, bool) {
+func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
 	if !strings.EqualFold(torrent.TrackerName, c.cfg.Domain) {
 		return nil, false
 	}
@@ -107,6 +108,7 @@ func (c *UNIT3D) IsUnregistered(torrent *Torrent) (error, bool) {
 	resp, err := rek.Get(url,
 		rek.Client(c.http),
 		rek.Headers(c.headers),
+		rek.Context(ctx),
 	)
 	if err != nil {
 		if resp == nil {


### PR DESCRIPTION
Pass context to all external calls like torrent clients and tracker requests.