### PR TITLE
refactor(tracker): remove logging from httputils

### DIFF
--- a/pkg/httputils/retryclient.go
+++ b/pkg/httputils/retryclient.go
@@ -5,13 +5,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
 	"github.com/autobrr/tqm/pkg/runtime"
 )
 
-func NewRetryableHttpClient(timeout time.Duration, rl ratelimit.Limiter, log *logrus.Entry) *http.Client {
+func NewRetryableHttpClient(timeout time.Duration, rl ratelimit.Limiter) *http.Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 1
 	retryClient.RetryWaitMin = 1 * time.Second
@@ -25,18 +24,6 @@ func NewRetryableHttpClient(timeout time.Duration, rl ratelimit.Limiter, log *lo
 		// rate limit
 		if rl != nil {
 			rl.Take()
-		}
-
-		// log
-		if log != nil && request != nil && request.URL != nil {
-			switch i {
-			case 0:
-				// first
-				log.Tracef("Sending request to %s", request.URL.String())
-			default:
-				// retry
-				log.Debugf("Retrying failed request to %s (attempt: %d)", request.URL.String(), i)
-			}
 		}
 	}
 	retryClient.HTTPClient.Timeout = timeout

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -47,7 +47,7 @@ func NewBHD(c BHDConfig) *BHD {
 	l := logger.GetLogger("bhd-api")
 	return &BHD{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		log:  l,
 	}
 }

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -71,11 +71,26 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	// Log API request details
 	c.log.Debugf("BHD API request for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
+	// Helper function to sanitize errors that might contain the API key
+	sanitizeError := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		errorMsg := err.Error()
+		if c.cfg.Key != "" && strings.Contains(errorMsg, c.cfg.Key) {
+			// Replace the API key with a placeholder
+			sanitized := strings.ReplaceAll(errorMsg, c.cfg.Key, "[API_KEY_REDACTED]")
+			return fmt.Errorf("%s", sanitized)
+		}
+		return err
+	}
+
 	// send request
 	resp, err := rek.Post(url, rek.Client(c.http), rek.Json(payload), rek.Context(ctx))
 	if err != nil {
-		c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-		return fmt.Errorf("bhd: request search: %w", err), false
+		safeErr := sanitizeError(err)
+		c.log.WithError(safeErr).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
+		return fmt.Errorf("bhd: request search: %w", safeErr), false
 	}
 	defer resp.Body().Close()
 
@@ -89,10 +104,10 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	// Read and parse the response
 	b := new(BHDAPIResponse)
 	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		// This covers both JSON parse errors (including HTML responses) in one check
-		c.log.WithError(err).Errorf("Failed decoding response for %s (hash: %s)",
+		safeErr := sanitizeError(err)
+		c.log.WithError(safeErr).Errorf("Failed decoding response for %s (hash: %s)",
 			torrent.Name, torrent.Hash)
-		return fmt.Errorf("bhd: decode response: %w", err), false
+		return fmt.Errorf("bhd: decode response: %w", safeErr), false
 	}
 
 	// Verify API response structure

--- a/pkg/tracker/btn.go
+++ b/pkg/tracker/btn.go
@@ -33,7 +33,7 @@ func NewBTN(c BTNConfig) *BTN {
 	l := logger.GetLogger("btn-api")
 	return &BTN{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		log:  l,
 	}
 }

--- a/pkg/tracker/hdb.go
+++ b/pkg/tracker/hdb.go
@@ -31,7 +31,7 @@ func NewHDB(c HDBConfig) *HDB {
 	l := logger.GetLogger("hdb-api")
 	return &HDB{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		log:  l,
 	}
 }

--- a/pkg/tracker/ops.go
+++ b/pkg/tracker/ops.go
@@ -30,7 +30,7 @@ func NewOPS(c OPSConfig) *OPS {
 	l := logger.GetLogger("ops-api")
 	return &OPS{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		log:  l,
 	}
 }

--- a/pkg/tracker/ptp.go
+++ b/pkg/tracker/ptp.go
@@ -33,7 +33,7 @@ func NewPTP(c PTPConfig) *PTP {
 	l := logger.GetLogger("ptp-api")
 	return &PTP{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		headers: map[string]string{
 			"ApiUser": c.User,
 			"ApiKey":  c.Key,

--- a/pkg/tracker/red.go
+++ b/pkg/tracker/red.go
@@ -30,7 +30,7 @@ func NewRED(c REDConfig) *RED {
 	l := logger.GetLogger("red-api")
 	return &RED{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		log:  l,
 	}
 }

--- a/pkg/tracker/unit3d.go
+++ b/pkg/tracker/unit3d.go
@@ -35,7 +35,7 @@ func NewUNIT3D(name string, c UNIT3DConfig) Interface {
 
 	return &UNIT3D{
 		cfg:  c,
-		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack), l),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		headers: map[string]string{
 			"Authorization": fmt.Sprintf("Bearer %s", c.APIKey),
 			"Accept":        "application/json",


### PR DESCRIPTION
Avoids leaking API tokens when used as part of the url.... looking at you BHD.