### PR TITLE
fix(notifications): don't escape discord embed titles

### DIFF
--- a/pkg/notification/discord.go
+++ b/pkg/notification/discord.go
@@ -527,7 +527,7 @@ func (d *discordSender) buildRetagField(torrent config.Torrent, newTags []string
 	jsonData, _ := json.Marshal(inlineFields)
 
 	return Field{
-		Name:  escapeDiscordMarkdown(fmt.Sprintf("%s (%s)", torrent.Name, humanize.IBytes(uint64(torrent.TotalBytes)))),
+		Name:  fmt.Sprintf("%s (%s)", torrent.Name, humanize.IBytes(uint64(torrent.TotalBytes))),
 		Value: string(jsonData),
 	}
 }
@@ -550,7 +550,7 @@ func (d *discordSender) buildRelabelField(torrent config.Torrent, newLabel strin
 	jsonData, _ := json.Marshal(inlineFields)
 
 	return Field{
-		Name:  escapeDiscordMarkdown(fmt.Sprintf("%s (%s)", torrent.Name, humanize.IBytes(uint64(torrent.TotalBytes)))),
+		Name:  fmt.Sprintf("%s (%s)", torrent.Name, humanize.IBytes(uint64(torrent.TotalBytes))),
 		Value: string(jsonData),
 	}
 }
@@ -607,7 +607,7 @@ func (d *discordSender) buildGenericField(torrent config.Torrent, reason string)
 	jsonData, _ := json.Marshal(inlineFields)
 
 	return Field{
-		Name:  escapeDiscordMarkdown(fmt.Sprintf("%s (%s)", torrent.Name, humanize.IBytes(uint64(torrent.TotalBytes)))),
+		Name:  fmt.Sprintf("%s (%s)", torrent.Name, humanize.IBytes(uint64(torrent.TotalBytes))),
 		Value: string(jsonData),
 	}
 }


### PR DESCRIPTION
Removed escaping for titles that have markdown formatting characters, because formatting is disabled there. It currently leads to something like this:
`[Saizen]\_Kuroko's\_Basketball\_-\_56\_[1080p][Blu-Ray][89693BBE].mkv` which should be
`[Saizen]_Kuroko's_Basketball_-_56_[1080p][Blu-Ray][89693BBE].mkv`.