### PR TITLE
fix(retag): avoid tag duplicates by using maps

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -58,16 +58,26 @@ func retagEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.TagI
 			continue
 		}
 
+		// Convert maps to slices for processing
+		var addTags []string
+		for tag := range retagInfo.Add {
+			addTags = append(addTags, tag)
+		}
+
+		var removeTags []string
+		for tag := range retagInfo.Remove {
+			removeTags = append(removeTags, tag)
+		}
+
 		// initialize with torrent values
-		finalTags := t.Tags
+		finalTags := removeSlice(t.Tags, removeTags)
+		finalTags = append(finalTags, addTags...)
 		limitKb := t.UpLimit
 
 		// retag
 		log.Info("-----")
 		actionLogs := []string{}
-		if len(retagInfo.Add) > 0 || len(retagInfo.Remove) > 0 {
-			currentTags := removeSlice(t.Tags, retagInfo.Remove)
-			finalTags = append(currentTags, retagInfo.Add...)
+		if len(addTags) > 0 || len(removeTags) > 0 {
 			actionLogs = append(actionLogs, fmt.Sprintf("Retagging to: [%s]", strings.Join(finalTags, ", ")))
 		}
 		if retagInfo.UploadKb != nil {
@@ -88,21 +98,21 @@ func retagEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.TagI
 
 		if !flagDryRun {
 			// apply tag changes
-			if len(retagInfo.Add) > 0 {
-				if err := c.AddTags(ctx, t.Hash, retagInfo.Add); err != nil {
-					log.WithError(err).Errorf("Failed adding tags %v to torrent: %+v", retagInfo.Add, t)
+			if len(addTags) > 0 {
+				if err := c.AddTags(ctx, t.Hash, addTags); err != nil {
+					log.WithError(err).Errorf("Failed adding tags %v to torrent: %+v", addTags, t)
 					actionFailed = true
 				} else {
-					log.Debugf("Added tags: %v", retagInfo.Add)
+					log.Debugf("Added tags: %v", addTags)
 					actionTaken = true
 				}
 			}
-			if len(retagInfo.Remove) > 0 && !actionFailed {
-				if err := c.RemoveTags(ctx, t.Hash, retagInfo.Remove); err != nil {
-					log.WithError(err).Errorf("Failed removing tags %v from torrent: %+v", retagInfo.Remove, t)
+			if len(removeTags) > 0 && !actionFailed {
+				if err := c.RemoveTags(ctx, t.Hash, removeTags); err != nil {
+					log.WithError(err).Errorf("Failed removing tags %v from torrent: %+v", removeTags, t)
 					actionFailed = true
 				} else {
-					log.Debugf("Removed tags: %v", retagInfo.Remove)
+					log.Debugf("Removed tags: %v", removeTags)
 					actionTaken = true
 				}
 			}

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -451,7 +451,10 @@ func (c *QBittorrent) PauseTorrents(ctx context.Context, hashes []string) error 
 }
 
 func (c *QBittorrent) ShouldRetag(ctx context.Context, t *config.Torrent) (RetagInfo, error) {
-	var retagInfo = RetagInfo{}
+	retagInfo := RetagInfo{
+		Add:    make(map[string]struct{}),
+		Remove: make(map[string]struct{}),
+	}
 	var uploadLimitSet = false
 
 	for _, tagRule := range c.exp.Tags {
@@ -465,10 +468,10 @@ func (c *QBittorrent) ShouldRetag(ctx context.Context, t *config.Torrent) (Retag
 		var tagMode = tagRule.Mode
 
 		if containTag && !match && (tagMode == "remove" || tagMode == "full") {
-			retagInfo.Remove = append(retagInfo.Remove, tagRule.Name)
+			retagInfo.Remove[tagRule.Name] = struct{}{}
 		}
 		if !containTag && match && (tagMode == "add" || tagMode == "full") {
-			retagInfo.Add = append(retagInfo.Add, tagRule.Name)
+			retagInfo.Add[tagRule.Name] = struct{}{}
 		}
 
 		if match && tagRule.UploadKb != nil && !uploadLimitSet {

--- a/pkg/client/tagInterface.go
+++ b/pkg/client/tagInterface.go
@@ -7,8 +7,8 @@ import (
 )
 
 type RetagInfo struct {
-	Add      []string
-	Remove   []string
+	Add      map[string]struct{}
+	Remove   map[string]struct{}
 	UploadKb *int64
 }
 


### PR DESCRIPTION
Avoids an edge case where tags get listed multiple times by avoiding using a slice in the ShouldRetag function.