### PR TITLE
fix(api): print torrent logs divider in API calls to preserve grouping

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -75,7 +75,10 @@ func retagEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.TagI
 		limitKb := t.UpLimit
 
 		// retag
-		log.Info("-----")
+		if !t.APIDividerPrinted {
+			log.Info("-----")
+		}
+
 		actionLogs := []string{}
 		if len(addTags) > 0 || len(removeTags) > 0 {
 			actionLogs = append(actionLogs, fmt.Sprintf("Retagging to: [%s]", strings.Join(finalTags, ", ")))
@@ -223,7 +226,10 @@ func relabelEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.In
 		}
 
 		// relabel
-		log.Info("-----")
+		if !t.APIDividerPrinted {
+			log.Info("-----")
+		}
+
 		if hardlink {
 			log.Infof("Relabeling: %q - %s | with hardlinks to: %q", t.Name, label, c.LabelPathMap()[label])
 		} else {
@@ -300,7 +306,10 @@ func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Int
 		// Check if torrent is unregistered (can bypass uniqueness checks)
 		if t.IsUnregistered(ctx) {
 			// For unregistered torrents, override safety checks
-			log.Info("-----")
+			if !t.APIDividerPrinted {
+				log.Info("-----")
+			}
+
 			if isHardlinked {
 				log.Infof("removing unregistered non-unique torrent (hardlinked): %q - %s", t.Name, humanize.IBytes(uint64(t.DownloadedBytes)))
 			} else {
@@ -384,7 +393,10 @@ func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Int
 	// helper function to remove torrent
 	removeTorrent := func(ctx context.Context, h string, t *config.Torrent, reason string) {
 		// remove the torrent
-		log.Info("-----")
+		if !t.APIDividerPrinted {
+			log.Info("-----")
+		}
+
 		if !t.FreeSpaceSet {
 			log.Infof("removing: %q - %s", t.Name, humanize.IBytes(uint64(t.DownloadedBytes)))
 		} else {

--- a/pkg/config/torrent.go
+++ b/pkg/config/torrent.go
@@ -134,6 +134,7 @@ type Torrent struct {
 
 	// set by command
 	HardlinkedOutsideClient bool `json:"-"`
+	APIDividerPrinted       bool `json:"-"`
 
 	regexPattern *regex.Pattern
 }
@@ -211,19 +212,21 @@ func (t *Torrent) IsUnregistered(ctx context.Context) bool {
 	// check tracker api (if available)
 	if tr := tracker.Get(t.TrackerName); tr != nil {
 		tt := &tracker.Torrent{
-			Hash:            t.Hash,
-			Name:            t.Name,
-			TotalBytes:      t.TotalBytes,
-			DownloadedBytes: t.DownloadedBytes,
-			State:           t.State,
-			Downloaded:      t.Downloaded,
-			Seeding:         t.Seeding,
-			TrackerName:     t.TrackerName,
-			TrackerStatus:   t.TrackerStatus,
-			Comment:         t.Comment,
+			Hash:              t.Hash,
+			Name:              t.Name,
+			TotalBytes:        t.TotalBytes,
+			DownloadedBytes:   t.DownloadedBytes,
+			State:             t.State,
+			Downloaded:        t.Downloaded,
+			Seeding:           t.Seeding,
+			TrackerName:       t.TrackerName,
+			TrackerStatus:     t.TrackerStatus,
+			Comment:           t.Comment,
+			APIDividerPrinted: t.APIDividerPrinted,
 		}
 
 		if err, ur := tr.IsUnregistered(ctx, tt); err == nil {
+			t.APIDividerPrinted = tt.APIDividerPrinted
 			return ur
 		}
 	}

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -69,6 +69,10 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	}
 
 	// Log API request details
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
 	c.log.Tracef("Querying BHD API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// Helper function to sanitize errors that might contain the API key

--- a/pkg/tracker/btn.go
+++ b/pkg/tracker/btn.go
@@ -66,6 +66,10 @@ func (c *BTN) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		return nil, false
 	}
 
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
 	c.log.Tracef("Querying BTN API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	torrentID, err := c.extractTorrentID(torrent.Comment)

--- a/pkg/tracker/hdb.go
+++ b/pkg/tracker/hdb.go
@@ -65,6 +65,11 @@ func (c *HDB) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		Data    []TorrentResult `json:"data"`
 	}
 
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
+
 	c.log.Tracef("Querying HDB API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request body

--- a/pkg/tracker/ops.go
+++ b/pkg/tracker/ops.go
@@ -56,6 +56,11 @@ func (c *OPS) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		} `json:"info"`
 	}
 
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
+
 	c.log.Tracef("Querying OPS API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request

--- a/pkg/tracker/ptp.go
+++ b/pkg/tracker/ptp.go
@@ -56,6 +56,11 @@ func (c *PTP) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		ResultDetails string `json:"ResultDetails"`
 	}
 
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
+
 	c.log.Tracef("Querying PTP API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request

--- a/pkg/tracker/red.go
+++ b/pkg/tracker/red.go
@@ -58,6 +58,11 @@ func (c *RED) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		} `json:"response"`
 	}
 
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
+
 	c.log.Tracef("Querying RED API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request

--- a/pkg/tracker/struct.go
+++ b/pkg/tracker/struct.go
@@ -24,4 +24,7 @@ type Torrent struct {
 	TrackerName   string
 	TrackerStatus string
 	Comment       string
+
+	// internal
+	APIDividerPrinted bool
 }

--- a/pkg/tracker/unit3d.go
+++ b/pkg/tracker/unit3d.go
@@ -75,6 +75,11 @@ func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, b
 		return nil, false
 	}
 
+	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		c.log.Info("-----")
+		torrent.APIDividerPrinted = true
+	}
+
 	if torrent.Comment == "" {
 		c.log.Debugf("Skipping torrent check - no comment available (likely Deluge client): %s", torrent.Name)
 		return nil, false


### PR DESCRIPTION
Embrace the jank.