### PR TITLE
perf(qbit): use SetTags if API version is supported

### DIFF
--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -498,7 +498,15 @@ func (c *QBittorrent) RemoveTags(ctx context.Context, hash string, tags []string
 	}
 
 	if err := c.client.RemoveTagsCtx(ctx, []string{hash}, strings.Join(tags, ",")); err != nil {
-		return fmt.Errorf("add torrent tags: %v: %w", tags, err)
+		return fmt.Errorf("remove torrent tags: %v: %w", tags, err)
+	}
+
+	return nil
+}
+
+func (c *QBittorrent) SetTags(ctx context.Context, hash string, tags []string) error {
+	if err := c.client.SetTags(ctx, []string{hash}, strings.Join(tags, ",")); err != nil {
+		return fmt.Errorf("set torrent tags: %v: %w", tags, err)
 	}
 
 	return nil

--- a/pkg/client/tagInterface.go
+++ b/pkg/client/tagInterface.go
@@ -18,6 +18,7 @@ type TagInterface interface {
 	ShouldRetag(ctx context.Context, t *config.Torrent) (RetagInfo, error)
 	AddTags(ctx context.Context, hash string, tags []string) error
 	RemoveTags(ctx context.Context, hash string, tags []string) error
+	SetTags(ctx context.Context, hash string, tags []string) error
 	CreateTags(ctx context.Context, tags []string) error
 	DeleteTags(ctx context.Context, tags []string) error
 }


### PR DESCRIPTION
This implements the SetTags endpoint added in qBit WebAPI version 2.11.4 and should provide a significant performance improvement when updating tags for a ton of torrents.