### PR TITLE
refactor(tracker): clean up API requests

### DIFF
--- a/pkg/config/torrent.go
+++ b/pkg/config/torrent.go
@@ -276,19 +276,23 @@ func (t *Torrent) IsUnregistered(ctx context.Context) bool {
 		}
 
 		trackerName := tr.Name()
-		if err, ur := tr.IsUnregistered(ctx, tt); err == nil {
-			switch ur {
-			case true:
-				log.Debugf("%s (hash: %s) confirmed as unregistered by %s API", t.Name, t.Hash, trackerName)
-				t.RegistrationState = UnregisteredState
-			default:
-				log.Debugf("%s (hash: %s) not reported as unregistered by %s API", t.Name, t.Hash, trackerName)
-				t.RegistrationState = RegisteredState
-			}
-
-			t.APIDividerPrinted = tt.APIDividerPrinted
-			return ur
+		err, ur := tr.IsUnregistered(ctx, tt)
+		if err != nil {
+			log.Errorf("Error checking unregistered tracker status of %s (hash: %s) using %s API: %v", t.Name, t.Hash, trackerName, err)
+			return false
 		}
+
+		switch ur {
+		case true:
+			log.Debugf("%s (hash: %s) confirmed as unregistered by %s API", t.Name, t.Hash, trackerName)
+			t.RegistrationState = UnregisteredState
+		default:
+			log.Debugf("%s (hash: %s) not reported as unregistered by %s API", t.Name, t.Hash, trackerName)
+			t.RegistrationState = RegisteredState
+		}
+
+		t.APIDividerPrinted = tt.APIDividerPrinted
+		return ur
 	}
 
 	t.RegistrationState = RegisteredState

--- a/pkg/config/torrent.go
+++ b/pkg/config/torrent.go
@@ -282,17 +282,19 @@ func (t *Torrent) IsUnregistered(ctx context.Context) bool {
 			return false
 		}
 
-		switch ur {
-		case true:
+		t.APIDividerPrinted = tt.APIDividerPrinted
+
+		if ur {
 			log.Debugf("%s (hash: %s) confirmed as unregistered by %s API", t.Name, t.Hash, trackerName)
 			t.RegistrationState = UnregisteredState
-		default:
-			log.Debugf("%s (hash: %s) not reported as unregistered by %s API", t.Name, t.Hash, trackerName)
-			t.RegistrationState = RegisteredState
+
+			return true
 		}
 
-		t.APIDividerPrinted = tt.APIDividerPrinted
-		return ur
+		log.Debugf("%s (hash: %s) not reported as unregistered by %s API", t.Name, t.Hash, trackerName)
+		t.RegistrationState = RegisteredState
+
+		return false
 	}
 
 	t.RegistrationState = RegisteredState

--- a/pkg/httputils/httputils.go
+++ b/pkg/httputils/httputils.go
@@ -1,7 +1,11 @@
-package http
+package httputils
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -41,4 +45,33 @@ func URLWithQuery(base string, q url.Values) (string, error) {
 
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+func MakeAPIRequest(ctx context.Context, client *http.Client, method string, requestURL string, body io.Reader, headers map[string]string, toType any) error {
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	buf := bufio.NewReader(res.Body)
+
+	if err = json.NewDecoder(buf).Decode(toType); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -1,19 +1,19 @@
 package tracker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/lucperkins/rek"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -22,34 +22,22 @@ type BHDConfig struct {
 }
 
 type BHD struct {
-	cfg  BHDConfig
-	http *nethttp.Client
-	log  *logrus.Entry
-}
-
-type BHDAPIRequest struct {
-	Hash   string `json:"info_hash"`
-	Action string `json:"action"`
-}
-
-type BHDAPIResponse struct {
-	StatusCode int `json:"status_code"`
-	Page       int `json:"page"`
-	Results    []struct {
-		Name     string `json:"name"`
-		InfoHash string `json:"info_hash"`
-	} `json:"results"`
-	TotalPages   int  `json:"total_pages"`
-	TotalResults int  `json:"total_results"`
-	Success      bool `json:"success"`
+	cfg     BHDConfig
+	http    *http.Client
+	headers map[string]string
+	log     *logrus.Entry
 }
 
 func NewBHD(c BHDConfig) *BHD {
 	l := logger.GetLogger("bhd-api")
 	return &BHD{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
-		log:  l,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		headers: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+		log: l,
 	}
 }
 
@@ -62,11 +50,23 @@ func (c *BHD) Check(host string) bool {
 }
 
 func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	// prepare request
-	requestURL, _ := url.JoinPath("https://beyond-hd.me/api/torrents", c.cfg.Key)
-	payload := &BHDAPIRequest{
-		Hash:   torrent.Hash,
-		Action: "search",
+	type request struct {
+		Hash   string `json:"info_hash"`
+		Action string `json:"action"`
+	}
+
+	type result struct {
+		Name     string `json:"name"`
+		InfoHash string `json:"info_hash"`
+	}
+
+	type response struct {
+		StatusCode   int      `json:"status_code"`
+		Page         int      `json:"page"`
+		Results      []result `json:"results"`
+		TotalPages   int      `json:"total_pages"`
+		TotalResults int      `json:"total_results"`
+		Success      bool     `json:"success"`
 	}
 
 	// Log API request details
@@ -74,6 +74,7 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		c.log.Info("-----")
 		torrent.APIDividerPrinted = true
 	}
+
 	c.log.Tracef("Querying BHD API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// Helper function to sanitize errors that might contain the API key
@@ -90,39 +91,31 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		return err
 	}
 
-	// send request
-	resp, err := rek.Post(requestURL, rek.Client(c.http), rek.Json(payload), rek.Context(ctx))
+	// prepare request
+	requestURL, _ := url.JoinPath("https://beyond-hd.me/api/torrents", c.cfg.Key)
+
+	payload := &request{
+		Hash:   torrent.Hash,
+		Action: "search",
+	}
+
+	body, err := json.Marshal(payload)
 	if err != nil {
-		safeErr := sanitizeError(err)
-		c.log.WithError(safeErr).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-		return fmt.Errorf("bhd: request search: %w", safeErr), false
-	}
-	defer resp.Body().Close()
-
-	// Check HTTP status code
-	if resp.StatusCode() != 200 {
-		c.log.Errorf("Failed API response for %s (hash: %s), response: %s",
-			torrent.Name, torrent.Hash, resp.Status())
-		return fmt.Errorf("bhd: non-200 response: %s", resp.Status()), false
+		return fmt.Errorf("marshalling request: %w", sanitizeError(err)), false
 	}
 
-	// Read and parse the response
-	b := new(BHDAPIResponse)
-	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		safeErr := sanitizeError(err)
-		c.log.WithError(safeErr).Errorf("Failed decoding response for %s (hash: %s)",
-			torrent.Name, torrent.Hash)
-		return fmt.Errorf("bhd: decode response: %w", safeErr), false
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodPost, requestURL, bytes.NewReader(body), c.headers, &resp)
+	if err != nil {
+		return fmt.Errorf("making api request: %w", sanitizeError(err)), false
 	}
 
 	// Verify API response structure
-	if !b.Success || b.StatusCode == 0 || b.Page == 0 {
-		c.log.Errorf("Invalid API response for %s (hash: %s): success=%t, status_code=%d, page=%d",
-			torrent.Name, torrent.Hash, b.Success, b.StatusCode, b.Page)
-		return fmt.Errorf("bhd: invalid API response"), false
+	if !resp.Success || resp.StatusCode == 0 || resp.Page == 0 {
+		return fmt.Errorf("API error"), false
 	}
 
-	return nil, b.TotalResults < 1
+	return nil, resp.TotalResults < 1
 }
 
 func (c *BHD) IsTrackerDown(_ *Torrent) (error, bool) {

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -90,7 +90,10 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		return err
 	}
 
-	requestURL, _ := url.JoinPath("https://beyond-hd.me/api/torrents", c.cfg.Key)
+	requestURL, err := url.JoinPath("https://beyond-hd.me/api/torrents", c.cfg.Key)
+	if err != nil {
+		return fmt.Errorf("creating request URL: %w", sanitizeError(err)), false
+	}
 
 	payload := &request{
 		Hash:   torrent.Hash,

--- a/pkg/tracker/bhd.go
+++ b/pkg/tracker/bhd.go
@@ -69,7 +69,6 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		Success      bool     `json:"success"`
 	}
 
-	// Log API request details
 	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
 		c.log.Info("-----")
 		torrent.APIDividerPrinted = true
@@ -91,7 +90,6 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		return err
 	}
 
-	// prepare request
 	requestURL, _ := url.JoinPath("https://beyond-hd.me/api/torrents", c.cfg.Key)
 
 	payload := &request{
@@ -110,7 +108,7 @@ func (c *BHD) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		return fmt.Errorf("making api request: %w", sanitizeError(err)), false
 	}
 
-	// Verify API response structure
+	// verify API response structure
 	if !resp.Success || resp.StatusCode == 0 || resp.Page == 0 {
 		return fmt.Errorf("API error"), false
 	}

--- a/pkg/tracker/btn.go
+++ b/pkg/tracker/btn.go
@@ -99,10 +99,6 @@ func (c *BTN) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 
 	c.log.Tracef("Querying BTN API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	if !strings.EqualFold(torrent.TrackerName, "landof.tv") {
-		return nil, false
-	}
-
 	torrentID, err := c.extractTorrentID(torrent.Comment)
 	if err != nil {
 		return fmt.Errorf("extracting torrent ID: %w", err), false

--- a/pkg/tracker/btn.go
+++ b/pkg/tracker/btn.go
@@ -126,23 +126,23 @@ func (c *BTN) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 		return fmt.Errorf("making api request: %w", err), false
 	}
 
-	// check for RPC error
 	if resp.Error != nil {
 		return fmt.Errorf("API error: %s (code: %d)", resp.Error.Message, resp.Error.Code), false
 	}
 
-	// check if we got any results
 	if resp.Result == nil {
 		return nil, true
 	}
 
-	// compare infohash
+	// compare hash
 	if strings.EqualFold(resp.Result.InfoHash, torrent.Hash) {
+		// torrent exists and hash matches
 		return nil, false
 	}
 
 	// if we get here, the torrent ID exists but hash doesn't match
-	c.log.Debugf("Torrent ID exists but hash mismatch for: %s", torrent.Name)
+	c.log.Debugf("Torrent ID exists but hash mismatch. Expected: %s, Got: %s",
+		torrent.Hash, resp.Result.InfoHash)
 	return nil, true
 }
 

--- a/pkg/tracker/btn.go
+++ b/pkg/tracker/btn.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -24,17 +24,22 @@ type BTNConfig struct {
 }
 
 type BTN struct {
-	cfg  BTNConfig
-	http *nethttp.Client
-	log  *logrus.Entry
+	cfg     BTNConfig
+	http    *http.Client
+	headers map[string]string
+	log     *logrus.Entry
 }
 
 func NewBTN(c BTNConfig) *BTN {
 	l := logger.GetLogger("btn-api")
 	return &BTN{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
-		log:  l,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		headers: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+		log: l,
 	}
 }
 
@@ -62,109 +67,78 @@ func (c *BTN) extractTorrentID(comment string) (string, error) {
 }
 
 func (c *BTN) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	if !strings.EqualFold(torrent.TrackerName, "landof.tv") || torrent.Comment == "" {
-		return nil, false
+	type request struct {
+		JsonRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+		Params  any    `json:"params"`
+		ID      int    `json:"id"`
+	}
+
+	type result struct {
+		InfoHash    string `json:"InfoHash"`
+		ReleaseName string `json:"ReleaseName"`
+	}
+
+	type rpcError struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    any    `json:"data,omitempty"`
+	}
+
+	type response struct {
+		JsonRPC string    `json:"jsonrpc"`
+		Result  *result   `json:"result,omitempty"`
+		Error   *rpcError `json:"error,omitempty"`
+		ID      int       `json:"id"`
 	}
 
 	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
 		c.log.Info("-----")
 		torrent.APIDividerPrinted = true
 	}
+
 	c.log.Tracef("Querying BTN API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	torrentID, err := c.extractTorrentID(torrent.Comment)
-	if err != nil {
+	if !strings.EqualFold(torrent.TrackerName, "landof.tv") {
 		return nil, false
 	}
 
-	type JSONRPCRequest struct {
-		JsonRPC string `json:"jsonrpc"`
-		Method  string `json:"method"`
-		Params  []any  `json:"params"`
-		ID      int    `json:"id"`
+	torrentID, err := c.extractTorrentID(torrent.Comment)
+	if err != nil {
+		return fmt.Errorf("extracting torrent ID: %w", err), false
 	}
 
-	type TorrentInfo struct {
-		InfoHash    string `json:"InfoHash"`
-		ReleaseName string `json:"ReleaseName"`
-	}
-
-	type JSONRPCResponse struct {
-		JsonRPC string `json:"jsonrpc"`
-		Result  struct {
-			Results  string                 `json:"results"`
-			Torrents map[string]TorrentInfo `json:"torrents"`
-		} `json:"result"`
-		Error *struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error,omitempty"`
-		ID int `json:"id"`
-	}
-
-	// prepare request
-	reqBody := JSONRPCRequest{
-		JsonRPC: "2.0",
-		Method:  "getTorrentsSearch",
-		Params:  []any{c.cfg.Key, map[string]any{"id": torrentID}, 1},
+	payload := &request{
 		ID:      1,
+		JsonRPC: "2.0",
+		Method:  "getTorrentById",
+		Params:  [2]string{c.cfg.Key, torrentID},
 	}
 
-	jsonBody, err := json.Marshal(reqBody)
+	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("btn: marshal request: %w", err), false
+		return fmt.Errorf("marshalling request: %w", err), false
 	}
 
-	// create request
-	req, err := nethttp.NewRequest(nethttp.MethodPost, "https://api.broadcasthe.net", bytes.NewReader(jsonBody))
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodPost, "https://api.broadcasthe.net", bytes.NewReader(body), c.headers, &resp)
 	if err != nil {
-		return fmt.Errorf("btn: create request: %w", err), false
-	}
-
-	// set headers
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	// send request
-	resp, err := c.http.Do(req)
-	if err != nil {
-		c.log.WithError(err).Errorf("Failed checking torrent %s (hash: %s)", torrent.Name, torrent.Hash)
-		return fmt.Errorf("btn: request check: %w", err), false
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != nethttp.StatusOK {
-		return fmt.Errorf("btn: unexpected status code: %d", resp.StatusCode), false
-	}
-
-	// decode response
-	var response JSONRPCResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return fmt.Errorf("btn: decode response: %w", err), false
+		return fmt.Errorf("making api request: %w", err), false
 	}
 
 	// check for RPC error
-	if response.Error != nil {
-		// check message content for IP authorization
-		if strings.Contains(strings.ToLower(response.Error.Message), "ip address needs authorization") {
-			c.log.Error("BTN API requires IP authorization. Please check your notices on BTN")
-			return fmt.Errorf("btn: IP authorization required - check BTN notices"), false
-		}
-
-		// default error case
-		return fmt.Errorf("btn: api error: %s (code: %d)", response.Error.Message, response.Error.Code), false
+	if resp.Error != nil {
+		return fmt.Errorf("API error: %s (code: %d)", resp.Error.Message, resp.Error.Code), false
 	}
 
 	// check if we got any results
-	if response.Result.Results == "0" || len(response.Result.Torrents) == 0 {
+	if resp.Result == nil {
 		return nil, true
 	}
 
 	// compare infohash
-	for _, t := range response.Result.Torrents {
-		if strings.EqualFold(t.InfoHash, torrent.Hash) {
-			return nil, false
-		}
+	if strings.EqualFold(resp.Result.InfoHash, torrent.Hash) {
+		return nil, false
 	}
 
 	// if we get here, the torrent ID exists but hash doesn't match

--- a/pkg/tracker/hdb.go
+++ b/pkg/tracker/hdb.go
@@ -1,18 +1,18 @@
 package tracker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
 	"strings"
 	"time"
 
-	"github.com/lucperkins/rek"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -22,17 +22,22 @@ type HDBConfig struct {
 }
 
 type HDB struct {
-	cfg  HDBConfig
-	http *nethttp.Client
-	log  *logrus.Entry
+	cfg     HDBConfig
+	http    *http.Client
+	headers map[string]string
+	log     *logrus.Entry
 }
 
 func NewHDB(c HDBConfig) *HDB {
 	l := logger.GetLogger("hdb-api")
 	return &HDB{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
-		log:  l,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		headers: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "application/json",
+		},
+		log: l,
 	}
 }
 
@@ -45,24 +50,22 @@ func (c *HDB) Check(host string) bool {
 }
 
 func (c *HDB) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	//c.log.Infof("Checking HDB torrent: %s", torrent.Name)
-
-	type Request struct {
+	type request struct {
 		Username string `json:"username"`
 		Passkey  string `json:"passkey"`
 		Hash     string `json:"hash"`
 	}
 
-	type TorrentResult struct {
+	type data struct {
 		ID   int    `json:"id"`
 		Hash string `json:"hash"`
 		Name string `json:"name"`
 	}
 
-	type Response struct {
-		Status  int             `json:"status"`
-		Message string          `json:"message"`
-		Data    []TorrentResult `json:"data"`
+	type response struct {
+		Status  int    `json:"status"`
+		Message string `json:"message"`
+		Data    []data `json:"data"`
 	}
 
 	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
@@ -73,44 +76,26 @@ func (c *HDB) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	c.log.Tracef("Querying HDB API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request body
-	reqBody := Request{
+	payload := &request{
 		Username: c.cfg.Username,
 		Passkey:  c.cfg.Passkey,
 		Hash:     strings.ToUpper(torrent.Hash),
 	}
 
-	// send request
-	resp, err := rek.Post("https://hdbits.org/api/torrents",
-		rek.Client(c.http),
-		rek.Json(reqBody),
-		rek.Context(ctx),
-	)
+	body, err := json.Marshal(payload)
 	if err != nil {
-		if resp == nil {
-			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-			return fmt.Errorf("hdb: request search: %w", err), false
-		}
-	}
-	defer resp.Body().Close()
-
-	// validate response
-	if resp.StatusCode() != 200 {
-		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
-			torrent.Name, torrent.Hash, resp.Status())
-		return fmt.Errorf("hdb: validate search response: %s", resp.Status()), false
+		return fmt.Errorf("marshalling request: %w", err), false
 	}
 
-	// decode response
-	b := new(Response)
-	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
-			torrent.Name, torrent.Hash)
-		return fmt.Errorf("hdb: decode search response: %w", err), false
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodPost, "https://hdbits.org/api/torrents", bytes.NewReader(body), c.headers, &resp)
+	if err != nil {
+		return fmt.Errorf("making api request: %w", err), false
 	}
 
 	// HDB returns status 0 for success, anything else is an error
 	// if we get no results for a valid hash, the torrent is unregistered
-	return nil, b.Status == 0 && len(b.Data) == 0
+	return nil, resp.Status == 0 && len(resp.Data) == 0
 }
 
 func (c *HDB) IsTrackerDown(_ *Torrent) (error, bool) {

--- a/pkg/tracker/hdb.go
+++ b/pkg/tracker/hdb.go
@@ -75,7 +75,6 @@ func (c *HDB) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 
 	c.log.Tracef("Querying HDB API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	// prepare request body
 	payload := &request{
 		Username: c.cfg.Username,
 		Passkey:  c.cfg.Passkey,

--- a/pkg/tracker/ops.go
+++ b/pkg/tracker/ops.go
@@ -61,7 +61,6 @@ func (c *OPS) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 
 	c.log.Tracef("Querying OPS API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	// prepare request
 	requestURL, err := httputils.URLWithQuery("https://orpheus.network/ajax.php", url.Values{
 		"action": []string{"torrent"},
 		"hash":   []string{torrent.Hash},

--- a/pkg/tracker/ops.go
+++ b/pkg/tracker/ops.go
@@ -2,17 +2,16 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
-	"github.com/lucperkins/rek"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -21,17 +20,22 @@ type OPSConfig struct {
 }
 
 type OPS struct {
-	cfg  OPSConfig
-	http *nethttp.Client
-	log  *logrus.Entry
+	cfg     OPSConfig
+	http    *http.Client
+	headers map[string]string
+	log     *logrus.Entry
 }
 
 func NewOPS(c OPSConfig) *OPS {
 	l := logger.GetLogger("ops-api")
 	return &OPS{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
-		log:  l,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		headers: map[string]string{
+			"Accept":        "application/json",
+			"Authorization": "token " + c.Key,
+		},
+		log: l,
 	}
 }
 
@@ -44,16 +48,10 @@ func (c *OPS) Check(host string) bool {
 }
 
 func (c *OPS) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	//c.log.Infof("Checking OPS torrent: %s", torrent.Name)
-
-	type Response struct {
+	type response struct {
 		Status   string `json:"status"`
 		Error    string `json:"error"`
 		Response any    `json:"response"`
-		Info     struct {
-			Source  string `json:"source"`
-			Version int    `json:"version"`
-		} `json:"info"`
 	}
 
 	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
@@ -64,40 +62,21 @@ func (c *OPS) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	c.log.Tracef("Querying OPS API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request
-	url := fmt.Sprintf("https://orpheus.network/ajax.php?action=torrent&hash=%s", strings.ToUpper(torrent.Hash))
-
-	// send request with API key in Authorization header
-	resp, err := rek.Get(url,
-		rek.Client(c.http),
-		rek.Headers(map[string]string{
-			"Authorization": fmt.Sprintf("token %s", c.cfg.Key),
-		}),
-		rek.Context(ctx),
-	)
+	requestURL, err := httputils.URLWithQuery("https://orpheus.network/ajax.php", url.Values{
+		"action": []string{"torrent"},
+		"hash":   []string{torrent.Hash},
+	})
 	if err != nil {
-		if resp == nil {
-			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-			return fmt.Errorf("ops: request search: %w", err), false
-		}
-	}
-	defer resp.Body().Close()
-
-	// validate response
-	if resp.StatusCode() != 200 {
-		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
-			torrent.Name, torrent.Hash, resp.Status())
-		return fmt.Errorf("ops: validate search response: %s", resp.Status()), false
+		return fmt.Errorf("creating request URL: %w", err), false
 	}
 
-	// decode response
-	b := new(Response)
-	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
-			torrent.Name, torrent.Hash)
-		return fmt.Errorf("ops: decode search response: %w", err), false
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodGet, requestURL, nil, c.headers, &resp)
+	if err != nil {
+		return fmt.Errorf("making api request: %w", err), false
 	}
 
-	return nil, b.Status == "failure" && b.Error == "bad parameters"
+	return nil, resp.Status == "failure" && resp.Error == "bad parameters"
 }
 
 func (c *OPS) IsTrackerDown(_ *Torrent) (error, bool) {

--- a/pkg/tracker/ptp.go
+++ b/pkg/tracker/ptp.go
@@ -62,7 +62,6 @@ func (c *PTP) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 
 	c.log.Tracef("Querying PTP API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	// prepare request
 	requestURL, err := httputils.URLWithQuery("https://passthepopcorn.me/torrents.php", url.Values{
 		"infohash": []string{torrent.Hash},
 	})

--- a/pkg/tracker/ptp.go
+++ b/pkg/tracker/ptp.go
@@ -2,18 +2,16 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/lucperkins/rek"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -24,7 +22,7 @@ type PTPConfig struct {
 
 type PTP struct {
 	cfg     PTPConfig
-	http    *nethttp.Client
+	http    *http.Client
 	headers map[string]string
 	log     *logrus.Entry
 }
@@ -33,8 +31,9 @@ func NewPTP(c PTPConfig) *PTP {
 	l := logger.GetLogger("ptp-api")
 	return &PTP{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		headers: map[string]string{
+			"Accept":  "application/json",
 			"ApiUser": c.User,
 			"ApiKey":  c.Key,
 		},
@@ -51,7 +50,7 @@ func (c *PTP) Check(host string) bool {
 }
 
 func (c *PTP) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	type Response struct {
+	type response struct {
 		Result        string `json:"Result"`
 		ResultDetails string `json:"ResultDetails"`
 	}
@@ -64,37 +63,20 @@ func (c *PTP) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	c.log.Tracef("Querying PTP API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request
-	requestURL, err := http.URLWithQuery("https://passthepopcorn.me/torrents.php", url.Values{
+	requestURL, err := httputils.URLWithQuery("https://passthepopcorn.me/torrents.php", url.Values{
 		"infohash": []string{torrent.Hash},
 	})
 	if err != nil {
-		return fmt.Errorf("ptp: url parse: %w", err), false
+		return fmt.Errorf("creating request URL: %w", err), false
 	}
 
-	// send request
-	resp, err := rek.Get(requestURL, rek.Client(c.http), rek.Headers(c.headers), rek.Context(ctx))
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodGet, requestURL, nil, c.headers, &resp)
 	if err != nil {
-		c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-		return fmt.Errorf("ptp: request search: %w", err), false
-	}
-	defer resp.Body().Close()
-
-	// validate response
-	if resp.StatusCode() != 200 {
-		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
-			torrent.Name, torrent.Hash, resp.Status())
-		return fmt.Errorf("ptp: validate search response: %s", resp.Status()), false
+		return fmt.Errorf("making api request: %w", err), false
 	}
 
-	// decode response
-	b := new(Response)
-	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
-			torrent.Name, torrent.Hash)
-		return fmt.Errorf("ptp: decode search response: %w", err), false
-	}
-
-	return nil, b.Result == "ERROR" && b.ResultDetails == "Unregistered Torrent"
+	return nil, resp.Result == "ERROR" && resp.ResultDetails == "Unregistered Torrent"
 }
 
 func (c *PTP) IsTrackerDown(_ *Torrent) (error, bool) {

--- a/pkg/tracker/red.go
+++ b/pkg/tracker/red.go
@@ -2,17 +2,16 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
-	"github.com/lucperkins/rek"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -21,17 +20,22 @@ type REDConfig struct {
 }
 
 type RED struct {
-	cfg  REDConfig
-	http *nethttp.Client
-	log  *logrus.Entry
+	cfg     REDConfig
+	http    *http.Client
+	headers map[string]string
+	log     *logrus.Entry
 }
 
 func NewRED(c REDConfig) *RED {
 	l := logger.GetLogger("red-api")
 	return &RED{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
-		log:  l,
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		headers: map[string]string{
+			"Accept":        "application/json",
+			"Authorization": "token " + c.Key,
+		},
+		log: l,
 	}
 }
 
@@ -44,18 +48,10 @@ func (c *RED) Check(host string) bool {
 }
 
 func (c *RED) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	//c.log.Infof("Checking RED torrent: %s", torrent.Name)
-
-	type Response struct {
+	type response struct {
 		Status   string `json:"status"`
 		Error    string `json:"error"`
-		Response struct {
-			Group   any `json:"group"`
-			Torrent struct {
-				ID       int    `json:"id"`
-				InfoHash string `json:"infoHash"`
-			} `json:"torrent"`
-		} `json:"response"`
+		Response any    `json:"response"`
 	}
 
 	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
@@ -66,40 +62,21 @@ func (c *RED) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 	c.log.Tracef("Querying RED API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
 	// prepare request
-	url := fmt.Sprintf("https://redacted.sh/ajax.php?action=torrent&hash=%s", strings.ToUpper(torrent.Hash))
-
-	// send request with API key in header
-	resp, err := rek.Get(url,
-		rek.Client(c.http),
-		rek.Headers(map[string]string{
-			"Authorization": c.cfg.Key,
-		}),
-		rek.Context(ctx),
-	)
+	requestURL, err := httputils.URLWithQuery("https://redacted.sh/ajax.php", url.Values{
+		"action": []string{"torrent"},
+		"hash":   []string{torrent.Hash},
+	})
 	if err != nil {
-		if resp == nil {
-			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-			return fmt.Errorf("redacted: request search: %w", err), false
-		}
-	}
-	defer resp.Body().Close()
-
-	// validate response
-	if resp.StatusCode() != 200 && resp.StatusCode() != 400 {
-		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
-			torrent.Name, torrent.Hash, resp.Status())
-		return fmt.Errorf("redacted: validate search response: %s", resp.Status()), false
+		return fmt.Errorf("creating request URL: %w", err), false
 	}
 
-	// decode response
-	b := new(Response)
-	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
-			torrent.Name, torrent.Hash)
-		return fmt.Errorf("redacted: decode search response: %w", err), false
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodGet, requestURL, nil, c.headers, &resp)
+	if err != nil {
+		return fmt.Errorf("making api request: %w", err), false
 	}
 
-	return nil, b.Status == "failure" && b.Error == "bad hash parameter"
+	return nil, resp.Status == "failure" && resp.Error == "bad hash parameter"
 }
 
 func (c *RED) IsTrackerDown(_ *Torrent) (error, bool) {

--- a/pkg/tracker/red.go
+++ b/pkg/tracker/red.go
@@ -61,7 +61,6 @@ func (c *RED) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool
 
 	c.log.Tracef("Querying RED API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	// prepare request
 	requestURL, err := httputils.URLWithQuery("https://redacted.sh/ajax.php", url.Values{
 		"action": []string{"torrent"},
 		"hash":   []string{torrent.Hash},

--- a/pkg/tracker/unit3d.go
+++ b/pkg/tracker/unit3d.go
@@ -88,10 +88,6 @@ func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, b
 
 	c.log.Tracef("Querying UNIT3D API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	if !strings.EqualFold(torrent.TrackerName, c.cfg.Domain) {
-		return nil, false
-	}
-
 	torrentID, err := c.extractTorrentID(torrent.Comment)
 	if err != nil {
 		return nil, false

--- a/pkg/tracker/unit3d.go
+++ b/pkg/tracker/unit3d.go
@@ -2,18 +2,16 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	nethttp "net/http"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/lucperkins/rek"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/ratelimit"
 
-	"github.com/autobrr/tqm/pkg/http"
+	"github.com/autobrr/tqm/pkg/httputils"
 	"github.com/autobrr/tqm/pkg/logger"
 )
 
@@ -24,18 +22,18 @@ type UNIT3DConfig struct {
 
 type UNIT3D struct {
 	cfg     UNIT3DConfig
-	http    *nethttp.Client
+	http    *http.Client
 	headers map[string]string
 	log     *logrus.Entry
 }
 
-// https://github.com/HDInnovations/UNIT3D-Community-Edition/wiki/Torrent-API-(UNIT3D-v8.3.4)
+// API docs: https://hdinnovations.github.io/UNIT3D/torrent_api.html
 func NewUNIT3D(name string, c UNIT3DConfig) Interface {
 	l := logger.GetLogger(fmt.Sprintf("%s-api", strings.ToLower(name)))
 
 	return &UNIT3D{
 		cfg:  c,
-		http: http.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
+		http: httputils.NewRetryableHttpClient(15*time.Second, ratelimit.New(1, ratelimit.WithoutSlack)),
 		headers: map[string]string{
 			"Authorization": fmt.Sprintf("Bearer %s", c.APIKey),
 			"Accept":        "application/json",
@@ -71,8 +69,16 @@ func (c *UNIT3D) extractTorrentID(comment string) (string, error) {
 }
 
 func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, bool) {
-	if !strings.EqualFold(torrent.TrackerName, c.cfg.Domain) {
-		return nil, false
+	type data struct {
+		Attributes struct {
+			InfoHash string `json:"info_hash"`
+		} `json:"attributes"`
+	}
+
+	type response struct {
+		Data    data   `json:"data"`
+		Message string `json:"message"`
+		Status  int    `json:"status"`
 	}
 
 	if c.log.Logger.IsLevelEnabled(logrus.DebugLevel) {
@@ -80,81 +86,38 @@ func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, b
 		torrent.APIDividerPrinted = true
 	}
 
-	if torrent.Comment == "" {
-		c.log.Debugf("Skipping torrent check - no comment available (likely Deluge client): %s", torrent.Name)
-		return nil, false
-	}
-
 	c.log.Tracef("Querying UNIT3D API for torrent: %s (hash: %s)", torrent.Name, torrent.Hash)
 
-	// extract torrent ID from comment
-	torrentID, err := c.extractTorrentID(torrent.Comment)
-	if err != nil {
-		//c.log.Debugf("Skipping torrent check - %v", err)
+	if !strings.EqualFold(torrent.TrackerName, c.cfg.Domain) {
 		return nil, false
 	}
 
-	type TorrentData struct {
-		Attributes struct {
-			InfoHash string `json:"info_hash"`
-		} `json:"attributes"`
-	}
-
-	type Response struct {
-		Data    TorrentData `json:"data"`
-		Message string      `json:"message"`
-		Status  int         `json:"status"`
+	torrentID, err := c.extractTorrentID(torrent.Comment)
+	if err != nil {
+		return nil, false
 	}
 
 	// prepare request
-	url := fmt.Sprintf("https://%s/api/torrents/%s", c.cfg.Domain, torrentID)
+	requestURL := fmt.Sprintf("https://%s/api/torrents/%s", c.cfg.Domain, torrentID)
 
-	// send request
-	resp, err := rek.Get(url,
-		rek.Client(c.http),
-		rek.Headers(c.headers),
-		rek.Context(ctx),
-	)
+	var resp *response
+	err = httputils.MakeAPIRequest(ctx, c.http, http.MethodGet, requestURL, nil, c.headers, &resp)
 	if err != nil {
-		if resp == nil {
-			c.log.WithError(err).Errorf("Failed searching for %s (hash: %s)", torrent.Name, torrent.Hash)
-			return fmt.Errorf("unit3d: request search: %w", err), false
-		}
-	}
-	defer resp.Body().Close()
-
-	if resp.StatusCode() == 404 {
-		//c.log.Debugf("Torrent not found: %s (hash: %s)", torrent.Name, torrent.Hash)
-		return nil, true
-	}
-
-	// validate other response codes
-	if resp.StatusCode() != 200 {
-		c.log.WithError(err).Errorf("Failed validating search response for %s (hash: %s), response: %s",
-			torrent.Name, torrent.Hash, resp.Status())
-		return fmt.Errorf("unit3d: validate search response: %s", resp.Status()), false
-	}
-
-	// decode response
-	b := new(Response)
-	if err := json.NewDecoder(resp.Body()).Decode(b); err != nil {
-		c.log.WithError(err).Errorf("Failed decoding search response for %s (hash: %s)",
-			torrent.Name, torrent.Hash)
-		return fmt.Errorf("unit3d: decode search response: %w", err), false
+		return fmt.Errorf("making api request: %w", err), false
 	}
 
 	// compare info hash
-	if strings.EqualFold(b.Data.Attributes.InfoHash, torrent.Hash) {
+	if strings.EqualFold(resp.Data.Attributes.InfoHash, torrent.Hash) {
 		// torrent exists and hash matches
 		return nil, false
 	}
 
 	// if we get here, the torrent ID exists but hash doesn't match
 	c.log.Debugf("Torrent ID exists but hash mismatch. Expected: %s, Got: %s",
-		torrent.Hash, b.Data.Attributes.InfoHash)
+		torrent.Hash, resp.Data.Attributes.InfoHash)
 	return nil, true
 }
 
-func (c *UNIT3D) IsTrackerDown(torrent *Torrent) (error, bool) {
+func (c *UNIT3D) IsTrackerDown(_ *Torrent) (error, bool) {
 	return nil, false
 }

--- a/pkg/tracker/unit3d.go
+++ b/pkg/tracker/unit3d.go
@@ -97,7 +97,6 @@ func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, b
 		return nil, false
 	}
 
-	// prepare request
 	requestURL := fmt.Sprintf("https://%s/api/torrents/%s", c.cfg.Domain, torrentID)
 
 	var resp *response
@@ -106,7 +105,7 @@ func (c *UNIT3D) IsUnregistered(ctx context.Context, torrent *Torrent) (error, b
 		return fmt.Errorf("making api request: %w", err), false
 	}
 
-	// compare info hash
+	// compare hash
 	if strings.EqualFold(resp.Data.Attributes.InfoHash, torrent.Hash) {
 		// torrent exists and hash matches
 		return nil, false


### PR DESCRIPTION
This updates the approach to API requests for every tracker that is currently definable in the config.
It removes the `rek` dependency and brings them all in line to be more consistent.