### PR TITLE
chore(torrent): add stream truncated as tracker down message

### DIFF
--- a/pkg/config/torrent.go
+++ b/pkg/config/torrent.go
@@ -107,6 +107,7 @@ var (
 		"host not found",
 		"offline",
 		"your request could not be processed, please try again later",
+		"stream truncated",
 	}
 
 	// set of statuses that indicate that the torrent is not yet fully uploaded, but not unregistered either


### PR DESCRIPTION
Adds `stream truncated` as a tracker message that would be considered as the tracker being down. Recently happened with BHD.