### PR TITLE
fix: correct multi-tracker status logic for both down and unregistered states

### DIFF
--- a/pkg/client/deluge.go
+++ b/pkg/client/deluge.go
@@ -192,6 +192,8 @@ func (c *Deluge) GetTorrents(ctx context.Context) (map[string]config.Torrent, er
 			// tracker
 			TrackerName:   t.TrackerHost,
 			TrackerStatus: t.TrackerStatus,
+			// Note: Deluge only uses one tracker at a time, so AllTrackerStatuses is not populated
+			AllTrackerStatuses: nil,
 		}
 
 		torrents[h] = torrent

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -165,6 +165,7 @@ func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torren
 		// parse tracker details
 		trackerName := ""
 		trackerStatus := ""
+		allTrackerStatuses := make(map[string]string)
 
 		var trackers []qbit.TorrentTracker
 
@@ -179,6 +180,7 @@ func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torren
 			trackers = ts
 		}
 
+		firstTrackerSet := false
 		for _, tr := range trackers {
 			// skip disabled trackers
 			if strings.Contains(tr.Url, "[DHT]") || strings.Contains(tr.Url, "[LSD]") ||
@@ -186,10 +188,17 @@ func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torren
 				continue
 			}
 
-			// use status of the first enabled tracker
-			trackerName = config.ParseTrackerDomain(tr.Url)
-			trackerStatus = tr.Message
-			break
+			// Store all tracker statuses
+			if tr.Message != "" {
+				allTrackerStatuses[tr.Url] = tr.Message
+			}
+
+			// Keep first tracker for backward compatibility
+			if !firstTrackerSet {
+				trackerName = config.ParseTrackerDomain(tr.Url)
+				trackerStatus = tr.Message
+				firstTrackerSet = true
+			}
 		}
 
 		// added time
@@ -247,9 +256,10 @@ func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torren
 			FreeSpaceGB:  c.GetFreeSpace,
 			FreeSpaceSet: c.freeSpaceSet,
 			// tracker
-			TrackerName:   trackerName,
-			TrackerStatus: trackerStatus,
-			Comment:       td.Comment,
+			TrackerName:        trackerName,
+			TrackerStatus:      trackerStatus,
+			AllTrackerStatuses: allTrackerStatuses,
+			Comment:            td.Comment,
 		}
 
 		torrents[t.Hash] = torrent

--- a/pkg/client/qbittorrent_test.go
+++ b/pkg/client/qbittorrent_test.go
@@ -1,0 +1,250 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/autobrr/go-qbittorrent"
+
+	"github.com/autobrr/tqm/pkg/config"
+)
+
+func TestQBittorrent_ProcessTrackerStatuses(t *testing.T) {
+	tests := []struct {
+		name                       string
+		trackers                   []qbittorrent.TorrentTracker
+		expectedTrackerName        string
+		expectedTrackerStatus      string
+		expectedAllTrackerStatuses map[string]string
+	}{
+		{
+			name: "multiple_trackers_first_down",
+			trackers: []qbittorrent.TorrentTracker{
+				{
+					Url:     "http://tracker1.com/announce",
+					Message: "Connection failed",
+				},
+				{
+					Url:     "http://tracker2.com/announce",
+					Message: "Working",
+				},
+				{
+					Url:     "http://tracker3.com/announce",
+					Message: "Active",
+				},
+			},
+			expectedTrackerName:   "tracker1.com",
+			expectedTrackerStatus: "Connection failed",
+			expectedAllTrackerStatuses: map[string]string{
+				"http://tracker1.com/announce": "Connection failed",
+				"http://tracker2.com/announce": "Working",
+				"http://tracker3.com/announce": "Active",
+			},
+		},
+		{
+			name: "skip_disabled_trackers",
+			trackers: []qbittorrent.TorrentTracker{
+				{
+					Url:     "[DHT]",
+					Message: "DHT active",
+				},
+				{
+					Url:     "[LSD]",
+					Message: "LSD active",
+				},
+				{
+					Url:     "[PeX]",
+					Message: "PeX active",
+				},
+				{
+					Url:     "http://tracker1.com/announce",
+					Message: "Working",
+				},
+			},
+			expectedTrackerName:   "tracker1.com",
+			expectedTrackerStatus: "Working",
+			expectedAllTrackerStatuses: map[string]string{
+				"http://tracker1.com/announce": "Working",
+			},
+		},
+		{
+			name: "empty_tracker_messages",
+			trackers: []qbittorrent.TorrentTracker{
+				{
+					Url:     "http://tracker1.com/announce",
+					Message: "",
+				},
+				{
+					Url:     "http://tracker2.com/announce",
+					Message: "Working",
+				},
+			},
+			expectedTrackerName:   "tracker1.com",
+			expectedTrackerStatus: "",
+			expectedAllTrackerStatuses: map[string]string{
+				"http://tracker2.com/announce": "Working",
+			},
+		},
+		{
+			name: "all_trackers_have_status",
+			trackers: []qbittorrent.TorrentTracker{
+				{
+					Url:     "http://tracker1.com/announce",
+					Message: "timeout",
+				},
+				{
+					Url:     "http://tracker2.com/announce",
+					Message: "connection refused",
+				},
+				{
+					Url:     "http://tracker3.com/announce",
+					Message: "bad gateway",
+				},
+			},
+			expectedTrackerName:   "tracker1.com",
+			expectedTrackerStatus: "timeout",
+			expectedAllTrackerStatuses: map[string]string{
+				"http://tracker1.com/announce": "timeout",
+				"http://tracker2.com/announce": "connection refused",
+				"http://tracker3.com/announce": "bad gateway",
+			},
+		},
+		{
+			name:                       "no_trackers",
+			trackers:                   []qbittorrent.TorrentTracker{},
+			expectedTrackerName:        "",
+			expectedTrackerStatus:      "",
+			expectedAllTrackerStatuses: map[string]string{},
+		},
+		{
+			name: "tracker_url_with_port",
+			trackers: []qbittorrent.TorrentTracker{
+				{
+					Url:     "http://tracker1.com:8080/announce",
+					Message: "Working",
+				},
+			},
+			expectedTrackerName:   "tracker1.com",
+			expectedTrackerStatus: "Working",
+			expectedAllTrackerStatuses: map[string]string{
+				"http://tracker1.com:8080/announce": "Working",
+			},
+		},
+		{
+			name: "tracker_url_with_subdomain",
+			trackers: []qbittorrent.TorrentTracker{
+				{
+					Url:     "http://announce.tracker1.com/announce",
+					Message: "Working",
+				},
+			},
+			expectedTrackerName:   "tracker1.com",
+			expectedTrackerStatus: "Working",
+			expectedAllTrackerStatuses: map[string]string{
+				"http://announce.tracker1.com/announce": "Working",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the tracker processing logic from GetTorrents
+			trackerName := ""
+			trackerStatus := ""
+			allTrackerStatuses := make(map[string]string)
+			firstTrackerSet := false
+
+			for _, tr := range tt.trackers {
+				// skip disabled trackers
+				if tr.Url == "[DHT]" || tr.Url == "[LSD]" || tr.Url == "[PeX]" {
+					continue
+				}
+
+				// Store all tracker statuses
+				if tr.Message != "" {
+					allTrackerStatuses[tr.Url] = tr.Message
+				}
+
+				// Keep first tracker for backward compatibility
+				if !firstTrackerSet {
+					trackerName = config.ParseTrackerDomain(tr.Url)
+					trackerStatus = tr.Message
+					firstTrackerSet = true
+				}
+			}
+
+			// Verify results
+			if trackerName != tt.expectedTrackerName {
+				t.Errorf("trackerName = %v, want %v", trackerName, tt.expectedTrackerName)
+			}
+			if trackerStatus != tt.expectedTrackerStatus {
+				t.Errorf("trackerStatus = %v, want %v", trackerStatus, tt.expectedTrackerStatus)
+			}
+			if len(allTrackerStatuses) != len(tt.expectedAllTrackerStatuses) {
+				t.Errorf("allTrackerStatuses length = %v, want %v", len(allTrackerStatuses), len(tt.expectedAllTrackerStatuses))
+			}
+			for url, status := range tt.expectedAllTrackerStatuses {
+				if got, ok := allTrackerStatuses[url]; !ok || got != status {
+					t.Errorf("allTrackerStatuses[%s] = %v, want %v", url, got, status)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTrackerDomain(t *testing.T) {
+	tests := []struct {
+		name           string
+		trackerHost    string
+		expectedDomain string
+	}{
+		{
+			name:           "simple_url",
+			trackerHost:    "http://tracker.com/announce",
+			expectedDomain: "tracker.com",
+		},
+		{
+			name:           "url_with_port",
+			trackerHost:    "http://tracker.com:8080/announce",
+			expectedDomain: "tracker.com",
+		},
+		{
+			name:           "url_with_subdomain",
+			trackerHost:    "http://announce.tracker.com/announce",
+			expectedDomain: "tracker.com",
+		},
+		{
+			name:           "https_url",
+			trackerHost:    "https://secure.tracker.com/announce",
+			expectedDomain: "tracker.com",
+		},
+		{
+			name:           "complex_subdomain",
+			trackerHost:    "http://announce.sub.tracker.com/announce",
+			expectedDomain: "tracker.com",
+		},
+		{
+			name:           "empty_host",
+			trackerHost:    "",
+			expectedDomain: "",
+		},
+		{
+			name:           "invalid_url",
+			trackerHost:    "not-a-url",
+			expectedDomain: "", // ParseTrackerDomain returns empty string for invalid URLs
+		},
+		{
+			name:           "ip_address",
+			trackerHost:    "http://192.168.1.1:8080/announce",
+			expectedDomain: "192.168.1.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ParseTrackerDomain(tt.trackerHost)
+			if got != tt.expectedDomain {
+				t.Errorf("ParseTrackerDomain(%s) = %v, want %v", tt.trackerHost, got, tt.expectedDomain)
+			}
+		})
+	}
+}

--- a/pkg/config/torrent_test.go
+++ b/pkg/config/torrent_test.go
@@ -1,0 +1,444 @@
+package config
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTorrent_IsTrackerDown(t *testing.T) {
+	tests := []struct {
+		name         string
+		torrent      Torrent
+		expectedDown bool
+	}{
+		{
+			name: "all_trackers_down",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Connection failed",
+					"http://tracker2.com/announce": "timeout",
+					"http://tracker3.com/announce": "service unavailable",
+				},
+			},
+			expectedDown: true,
+		},
+		{
+			name: "some_trackers_down_some_working",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Connection failed",
+					"http://tracker2.com/announce": "Working",
+					"http://tracker3.com/announce": "timeout",
+				},
+			},
+			expectedDown: false,
+		},
+		{
+			name: "all_trackers_working",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+					"http://tracker2.com/announce": "Active",
+					"http://tracker3.com/announce": "Connected",
+				},
+			},
+			expectedDown: false,
+		},
+		{
+			name: "empty_tracker_statuses",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{},
+			},
+			expectedDown: false,
+		},
+		{
+			name: "nil_AllTrackerStatuses_with_single_tracker_down",
+			torrent: Torrent{
+				TrackerStatus: "Connection failed",
+			},
+			expectedDown: true,
+		},
+		{
+			name: "nil_AllTrackerStatuses_with_single_tracker_working",
+			torrent: Torrent{
+				TrackerStatus: "Working",
+			},
+			expectedDown: false,
+		},
+		{
+			name: "mixed_http_errors",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "bad request",
+					"http://tracker2.com/announce": "unauthorized",
+					"http://tracker3.com/announce": "internal server error",
+				},
+			},
+			expectedDown: true,
+		},
+		{
+			name: "case_insensitive_status_check",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "CONNECTION FAILED",
+					"http://tracker2.com/announce": "TIMEOUT",
+					"http://tracker3.com/announce": "Service Unavailable",
+				},
+			},
+			expectedDown: true,
+		},
+		{
+			name: "empty_status_messages",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "",
+					"http://tracker2.com/announce": "",
+					"http://tracker3.com/announce": "timeout",
+				},
+			},
+			expectedDown: true,
+		},
+		{
+			name: "only_empty_status_messages",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "",
+					"http://tracker2.com/announce": "",
+				},
+			},
+			expectedDown: false,
+		},
+		{
+			name: "tracker_maintenance",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "tracker is down for maintenance",
+					"http://tracker2.com/announce": "maintenance mode",
+				},
+			},
+			expectedDown: true,
+		},
+		{
+			name: "ssl_and_network_errors",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "ssl error occurred",
+					"http://tracker2.com/announce": "host not found",
+					"http://tracker3.com/announce": "unresolvable",
+				},
+			},
+			expectedDown: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.torrent.IsTrackerDown()
+			if got != tt.expectedDown {
+				t.Errorf("IsTrackerDown() = %v, want %v", got, tt.expectedDown)
+			}
+		})
+	}
+}
+
+func TestTorrent_IsIntermediateStatus(t *testing.T) {
+	tests := []struct {
+		name                 string
+		torrent              Torrent
+		expectedIntermediate bool
+	}{
+		{
+			name: "torrent_postponed_bhd",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "torrent has been postponed",
+				},
+			},
+			expectedIntermediate: true,
+		},
+		{
+			name: "mixed_statuses_with_intermediate",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+					"http://tracker2.com/announce": "torrent has been postponed",
+				},
+			},
+			expectedIntermediate: true,
+		},
+		{
+			name: "no_intermediate_status",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+					"http://tracker2.com/announce": "Active",
+				},
+			},
+			expectedIntermediate: false,
+		},
+		{
+			name: "case_insensitive_intermediate_check",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "TORRENT HAS BEEN POSTPONED",
+				},
+			},
+			expectedIntermediate: true,
+		},
+		{
+			name: "nil_AllTrackerStatuses_with_intermediate",
+			torrent: Torrent{
+				TrackerStatus: "torrent has been postponed",
+			},
+			expectedIntermediate: true,
+		},
+		{
+			name: "nil_AllTrackerStatuses_no_intermediate",
+			torrent: Torrent{
+				TrackerStatus: "Working",
+			},
+			expectedIntermediate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.torrent.IsIntermediateStatus()
+			if got != tt.expectedIntermediate {
+				t.Errorf("IsIntermediateStatus() = %v, want %v", got, tt.expectedIntermediate)
+			}
+		})
+	}
+}
+
+func TestTorrent_IsUnregistered(t *testing.T) {
+	// Initialize the tracker statuses for tests
+	InitializeTrackerStatuses(nil)
+
+	tests := []struct {
+		name          string
+		torrent       Torrent
+		expectedUnreg bool
+	}{
+		{
+			name: "one_tracker_unregistered",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+					"http://tracker2.com/announce": "unregistered torrent",
+					"http://tracker3.com/announce": "Active",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "all_trackers_down_safety_mechanism",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Connection failed",
+					"http://tracker2.com/announce": "timeout",
+					"http://tracker3.com/announce": "service unavailable",
+				},
+			},
+			expectedUnreg: false,
+		},
+		{
+			name: "intermediate_status_prevents_unregistered",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "torrent has been postponed",
+					"http://tracker2.com/announce": "unregistered",
+				},
+			},
+			expectedUnreg: false,
+		},
+		{
+			name: "mixed_unregistered_messages",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+					"http://tracker2.com/announce": "torrent not found",
+					"http://tracker3.com/announce": "Active",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "torrent_deleted",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "torrent has been deleted",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "torrent_nuked",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+					"http://tracker2.com/announce": "torrent has been nuked",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "season_pack_available",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "season pack available",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "trumped_torrent",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "trumped by better quality",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "nil_AllTrackerStatuses_unregistered",
+			torrent: Torrent{
+				TrackerName:   "tracker.com",
+				TrackerStatus: "unregistered torrent",
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "nil_AllTrackerStatuses_working",
+			torrent: Torrent{
+				TrackerName:   "tracker.com",
+				TrackerStatus: "Working",
+			},
+			expectedUnreg: false,
+		},
+		{
+			name: "case_insensitive_unregistered_check",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "UNREGISTERED TORRENT",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "empty_tracker_status",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "",
+				},
+			},
+			expectedUnreg: false,
+		},
+		{
+			name: "cached_registration_state_unregistered",
+			torrent: Torrent{
+				RegistrationState: UnregisteredState,
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "Working",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "cached_registration_state_registered",
+			torrent: Torrent{
+				RegistrationState: RegisteredState,
+				AllTrackerStatuses: map[string]string{
+					"http://tracker1.com/announce": "unregistered",
+				},
+			},
+			expectedUnreg: false,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.torrent.IsUnregistered(ctx)
+			if got != tt.expectedUnreg {
+				t.Errorf("IsUnregistered() = %v, want %v", got, tt.expectedUnreg)
+			}
+		})
+	}
+}
+
+func TestTorrent_IsUnregistered_PerTrackerOverrides(t *testing.T) {
+	// Test with per-tracker custom unregistered statuses
+	perTrackerOverrides := map[string][]string{
+		"specialtracker.com": {"custom unregistered message", "special removal reason"},
+		"anothertracker.com": {"different error", "unique status"},
+	}
+	InitializeTrackerStatuses(perTrackerOverrides)
+
+	tests := []struct {
+		name          string
+		torrent       Torrent
+		expectedUnreg bool
+	}{
+		{
+			name: "custom_tracker_unregistered_message",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://specialtracker.com/announce": "custom unregistered message",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "custom_tracker_different_message",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://anothertracker.com/announce": "different error",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "default_unregistered_message_on_custom_tracker",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://specialtracker.com/announce": "unregistered",
+				},
+			},
+			expectedUnreg: false, // Custom tracker doesn't include "unregistered" in its list
+		},
+		{
+			name: "normal_tracker_with_default_messages",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://normaltracker.com/announce": "unregistered",
+				},
+			},
+			expectedUnreg: true,
+		},
+		{
+			name: "mixed_custom_and_default_trackers",
+			torrent: Torrent{
+				AllTrackerStatuses: map[string]string{
+					"http://specialtracker.com/announce": "Working",
+					"http://normaltracker.com/announce":  "torrent not found",
+					"http://anothertracker.com/announce": "Active",
+				},
+			},
+			expectedUnreg: true,
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.torrent.IsUnregistered(ctx)
+			if got != tt.expectedUnreg {
+				t.Errorf("IsUnregistered() = %v, want %v", got, tt.expectedUnreg)
+			}
+		})
+	}
+
+	// Reset to default for other tests
+	InitializeTrackerStatuses(nil)
+}


### PR DESCRIPTION
Previously, torrents with multiple trackers could be incorrectly marked based on a single tracker's status. This fix ensures proper handling:

- TrackerDown: Only when ALL trackers are down (no working trackers)
- IsUnregistered: When ANY tracker reports the torrent as unregistered
- Safety mechanism: Never mark as unregistered if all trackers are down
- Maintains backward compatibility with single tracker status