### PR TITLE
feat(retag): make tag creation configurable to prevent empty tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ clients:
       /downloads/torrents/qbittorrent/completed: /mnt/local/downloads/torrents/qbittorrent/completed
     enabled: true
     filter: default
+    create_tags_upfront: false # Only sets tags that matches torrents, prevents empty tags
     type: qbittorrent
     url: https://qbittorrent.domain.com/
     user: user

--- a/cmd/retag.go
+++ b/cmd/retag.go
@@ -155,6 +155,19 @@ var retagCmd = &cobra.Command{
 			log.Warnf("If your setup involves multiple torrents sharing the same underlying file using hardlinks, or you are using the 'HardlinkedOutsideClient' field in your filters, you should add 'retag' to the 'MapHardlinksFor' field in your filter configuration")
 		}
 
+		// Verify tags exist on client if configured to create upfront
+		if qbtClient, ok := ct.(*client.QBittorrent); ok && qbtClient.CreateTagsUpfront {
+			var tagList []string
+			for _, v := range exp.Tags {
+				tagList = append(tagList, v.Name)
+			}
+			if err := ct.CreateTags(ctx, tagList); err != nil {
+				log.WithError(err).Fatal("Failed to create tags on client")
+			} else {
+				log.Infof("Verified tags exist on client")
+			}
+		}
+
 		// relabel torrents that meet the filter criteria
 		if err := retagEligibleTorrents(ctx, log, ct, torrents, noti, clientName, startTime); err != nil {
 			log.WithError(err).Fatal("Failed retagging eligible torrents...")

--- a/cmd/retag.go
+++ b/cmd/retag.go
@@ -155,17 +155,6 @@ var retagCmd = &cobra.Command{
 			log.Warnf("If your setup involves multiple torrents sharing the same underlying file using hardlinks, or you are using the 'HardlinkedOutsideClient' field in your filters, you should add 'retag' to the 'MapHardlinksFor' field in your filter configuration")
 		}
 
-		// Verify tags exist on client
-		var tagList []string
-		for _, v := range exp.Tags {
-			tagList = append(tagList, v.Name)
-		}
-		if err := ct.CreateTags(ctx, tagList); err != nil {
-			log.WithError(err).Fatal("Failed to create tags on client")
-		} else {
-			log.Infof("Verified tags exist on client")
-		}
-
 		// relabel torrents that meet the filter criteria
 		if err := retagEligibleTorrents(ctx, log, ct, torrents, noti, clientName, startTime); err != nil {
 			log.WithError(err).Fatal("Failed retagging eligible torrents...")

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -26,6 +26,7 @@ type QBittorrent struct {
 	User                      string
 	Password                  string
 	EnableAutoTmmAfterRelabel bool
+	CreateTagsUpfront         bool `koanf:"create_tags_upfront"`
 
 	// internal
 	log        *logrus.Entry
@@ -50,6 +51,7 @@ func NewQBittorrent(name string, exp *expression.Expressions) (TagInterface, err
 		log:        logger.GetLogger(name),
 		clientType: "qBittorrent",
 		exp:        exp,
+		CreateTagsUpfront: true,
 	}
 
 	// load config


### PR DESCRIPTION
Add `create_tags_upfront` config option for qBittorrent clients to control tag pre-creation.

- Defaults to `true` for backward compatibility
- When `false`, only creates tags when applying them to torrents
- Prevents empty tags in qBittorrent

Fixes #74