### PR TITLE
feat(qbit): add key_torrent_last_activity_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ filters:
       # - name: completed-torrents
       #   update:
       #     - Downloaded == true
+      - name: inactive
+        mode: add
+        update:
+          - LastActivityDays > 30
     # Orphan configuration
     orphan:
       # grace period for recently modified files (default: 10m)
@@ -202,28 +206,31 @@ The following torrent fields (along with their types) can be used in the configu
 
 ```go
 type Torrent struct {
- Hash            string
- Name            string
- Path            string
- TotalBytes      int64
- DownloadedBytes int64
- State           string
- Files           []string
- Tags            []string
- Downloaded      bool
- Seeding         bool
- Ratio           float32
- AddedSeconds    int64
- AddedHours      float32
- AddedDays       float32
- SeedingSeconds  int64
- SeedingHours    float32
- SeedingDays     float32
- Label           string
- Seeds           int64
- Peers           int64
- IsPrivate       bool
- IsPublic        bool
+ Hash                 string
+ Name                 string
+ Path                 string
+ TotalBytes           int64
+ DownloadedBytes      int64
+ State                string
+ Files                []string
+ Tags                 []string
+ Downloaded           bool
+ Seeding              bool
+ Ratio                float32
+ AddedSeconds         int64
+ AddedHours           float32
+ AddedDays            float32
+ SeedingSeconds       int64
+ SeedingHours         float32
+ SeedingDays          float32
+ LastActivitySeconds  int64
+ LastActivityHours    float32
+ LastActivityDays     float32
+ Label                string
+ Seeds                int64
+ Peers                int64
+ IsPrivate            bool
+ IsPublic             bool
 
  FreeSpaceGB  func() float64
  FreeSpaceSet bool

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -48,9 +48,9 @@ type QBittorrent struct {
 
 func NewQBittorrent(name string, exp *expression.Expressions) (TagInterface, error) {
 	tc := QBittorrent{
-		log:        logger.GetLogger(name),
-		clientType: "qBittorrent",
-		exp:        exp,
+		log:               logger.GetLogger(name),
+		clientType:        "qBittorrent",
+		exp:               exp,
 		CreateTagsUpfront: true,
 	}
 
@@ -206,6 +206,10 @@ func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torren
 
 		seedingTime := time.Duration(td.SeedingTime) * time.Second
 
+		// last activity time
+		lastActivitySecs := max(
+			int64(time.Since(time.Unix(t.LastActivity, 0)).Seconds()), 0)
+
 		// torrent files
 		var files []string
 		for _, f := range *tf {
@@ -239,19 +243,22 @@ func (c *QBittorrent) GetTorrents(ctx context.Context) (map[string]config.Torren
 				"uploading",
 				"stalledUP",
 			}, string(t.State), true),
-			Ratio:          float32(td.ShareRatio),
-			AddedSeconds:   addedTimeSecs,
-			AddedHours:     float32(addedTimeSecs) / 60 / 60,
-			AddedDays:      float32(addedTimeSecs) / 60 / 60 / 24,
-			SeedingSeconds: int64(seedingTime.Seconds()),
-			SeedingHours:   float32(seedingTime.Seconds()) / 60 / 60,
-			SeedingDays:    float32(seedingTime.Seconds()) / 60 / 60 / 24,
-			UpLimit:        int64(td.UpLimit),
-			Label:          t.Category,
-			Seeds:          int64(td.SeedsTotal),
-			Peers:          int64(td.PeersTotal),
-			IsPrivate:      td.IsPrivate,
-			IsPublic:       !td.IsPrivate,
+			Ratio:               float32(td.ShareRatio),
+			AddedSeconds:        addedTimeSecs,
+			AddedHours:          float32(addedTimeSecs) / 60 / 60,
+			AddedDays:           float32(addedTimeSecs) / 60 / 60 / 24,
+			SeedingSeconds:      int64(seedingTime.Seconds()),
+			SeedingHours:        float32(seedingTime.Seconds()) / 60 / 60,
+			SeedingDays:         float32(seedingTime.Seconds()) / 60 / 60 / 24,
+			LastActivitySeconds: lastActivitySecs,
+			LastActivityHours:   float32(lastActivitySecs) / 60 / 60,
+			LastActivityDays:    float32(lastActivitySecs) / 60 / 60 / 24,
+			UpLimit:             int64(td.UpLimit),
+			Label:               t.Category,
+			Seeds:               int64(td.SeedsTotal),
+			Peers:               int64(td.PeersTotal),
+			IsPrivate:           td.IsPrivate,
+			IsPublic:            !td.IsPrivate,
 			// free space
 			FreeSpaceGB:  c.GetFreeSpace,
 			FreeSpaceSet: c.freeSpaceSet,

--- a/pkg/config/torrent.go
+++ b/pkg/config/torrent.go
@@ -120,29 +120,32 @@ var (
 
 type Torrent struct {
 	// torrent
-	Hash            string   `json:"Hash"`
-	Name            string   `json:"Name"`
-	Path            string   `json:"Path"`
-	TotalBytes      int64    `json:"TotalBytes"`
-	DownloadedBytes int64    `json:"DownloadedBytes"`
-	State           string   `json:"State"`
-	Files           []string `json:"Files"`
-	Tags            []string `json:"Tags"`
-	Downloaded      bool     `json:"Downloaded"`
-	Seeding         bool     `json:"Seeding"`
-	Ratio           float32  `json:"Ratio"`
-	AddedSeconds    int64    `json:"AddedSeconds"`
-	AddedHours      float32  `json:"AddedHours"`
-	AddedDays       float32  `json:"AddedDays"`
-	SeedingSeconds  int64    `json:"SeedingSeconds"`
-	SeedingHours    float32  `json:"SeedingHours"`
-	SeedingDays     float32  `json:"SeedingDays"`
-	Label           string   `json:"Label"`
-	Seeds           int64    `json:"Seeds"`
-	Peers           int64    `json:"Peers"`
-	IsPrivate       bool     `json:"IsPrivate"`
-	IsPublic        bool     `json:"IsPublic"`
-	UpLimit         int64    `json:"UpLimit,omitempty"`
+	Hash                string   `json:"Hash"`
+	Name                string   `json:"Name"`
+	Path                string   `json:"Path"`
+	TotalBytes          int64    `json:"TotalBytes"`
+	DownloadedBytes     int64    `json:"DownloadedBytes"`
+	State               string   `json:"State"`
+	Files               []string `json:"Files"`
+	Tags                []string `json:"Tags"`
+	Downloaded          bool     `json:"Downloaded"`
+	Seeding             bool     `json:"Seeding"`
+	Ratio               float32  `json:"Ratio"`
+	AddedSeconds        int64    `json:"AddedSeconds"`
+	AddedHours          float32  `json:"AddedHours"`
+	AddedDays           float32  `json:"AddedDays"`
+	SeedingSeconds      int64    `json:"SeedingSeconds"`
+	SeedingHours        float32  `json:"SeedingHours"`
+	SeedingDays         float32  `json:"SeedingDays"`
+	LastActivitySeconds int64    `json:"LastActivitySeconds"`
+	LastActivityHours   float32  `json:"LastActivityHours"`
+	LastActivityDays    float32  `json:"LastActivityDays"`
+	Label               string   `json:"Label"`
+	Seeds               int64    `json:"Seeds"`
+	Peers               int64    `json:"Peers"`
+	IsPrivate           bool     `json:"IsPrivate"`
+	IsPublic            bool     `json:"IsPublic"`
+	UpLimit             int64    `json:"UpLimit,omitempty"`
 
 	// set by client on GetCurrentFreeSpace
 	FreeSpaceGB  func() float64 `json:"-"`


### PR DESCRIPTION
Resolves https://github.com/autobrr/tqm/issues/82

Test performed with the following config:

```yaml
clients:
  qbt:
    download_path: /home/user/Downloads
    enabled: true
    filter: default
    type: qbittorrent
    url: http://127.0.0.1:8080
notifications:
filters:
  default:
    tag:
      # THIS IS THE NEW SECTION
      - name: inactive-10mins
        mode: add
        update:
          - LastActivitySeconds > 600
```

Results:
1. When item's last activity was <10 minutes ago: `Ignored torrents: 1, Retagged torrents: 0, 0 failures`
2. When item's last activity was >10 minutes ago: `Ignored torrents: 0, Retagged torrents: 1, 0 failures`. Confirmed that tag **inactive-10mins** was automatically added.