### PR TITLE
feat(cross-seed): safer relabeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ filters:
       - HardlinkedOutsideClient == true && !isUnregistered() # this makes sure we never remove torrents that has a hardlink (unless they are unregistered)
 ```
 
+:warning: To prevent potential data corruption or incomplete moves when TMM is used, relabeling of cross-seeded torrents only happens when ALL torrents of the same group (share the same underlying data) match the criteria (e.g. `SeedingDays >= 7.0`)
+
 **Recommendation:**
 
 - Include a command name in `MapHardlinksFor` only if your filter rules for that specific command use the `HardlinkedOutsideClient` field.
@@ -448,6 +450,8 @@ filters:
 `tqm relabel qbt --dry-run`
 
 `tqm relabel qbt`
+
+`tqm relabel qbt -v --experimental-relabel` - Enable experimental relabeling for cross-seeded torrents, using hardlinks (only qbit for now)
 
 3. Retag - Retrieve torrent client queue and retag torrents matching its configured filters (only qbittorrent supported as of now)
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -246,9 +246,6 @@ func relabelEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.In
 
 			canRelabelGroup := true
 			for _, groupTorrent := range group {
-				if groupTorrent.Hash == t.Hash {
-					continue
-				}
 				groupLabel, groupRelabel, err := c.ShouldRelabel(ctx, &groupTorrent)
 				if err != nil || !groupRelabel || groupLabel != label {
 					canRelabelGroup = false
@@ -309,14 +306,6 @@ func relabelTorrent(ctx context.Context, log *logrus.Entry, c client.Interface, 
 	if !t.APIDividerPrinted {
 		log.Info("-----")
 	}
-
-	if hardlink {
-		log.Infof("Relabeling: %q - %s | with hardlinks to: %q", t.Name, label, c.LabelPathMap()[label])
-	} else {
-		log.Infof("Relabeling: %q - %s", t.Name, label)
-	}
-	log.Infof("Ratio: %.3f / Seed days: %.3f / Seeds: %d / Label: %s / Tags: %s / Tracker: %s / "+
-		"Tracker Status: %q", t.Ratio, t.SeedingDays, t.Seeds, t.Label, strings.Join(t.Tags, ", "), t.TrackerName, t.TrackerStatus)
 
 	if !flagDryRun {
 		if err := c.SetTorrentLabel(ctx, t.Hash, label, hardlink); err != nil {

--- a/pkg/torrentfilemap/torrentfilemap.go
+++ b/pkg/torrentfilemap/torrentfilemap.go
@@ -86,6 +86,28 @@ func (t *TorrentFileMap) IsUnique(torrent config.Torrent) bool {
 	return true
 }
 
+func (t *TorrentFileMap) GetTorrentsSharingFiles(torrent config.Torrent, allTorrents map[string]config.Torrent) ([]config.Torrent, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	groupHashes := make(map[string]bool)
+	groupHashes[torrent.Hash] = true
+
+	for _, f := range torrent.Files {
+		if torrents, exists := t.torrentFileMap[f]; exists {
+			for hash := range torrents {
+				groupHashes[hash] = true
+			}
+		}
+	}
+
+	var group []config.Torrent
+	for hash := range groupHashes {
+		group = append(group, allTorrents[hash])
+	}
+	return group, nil
+}
+
 func (t *TorrentFileMap) NoInstances(torrent config.Torrent) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()


### PR DESCRIPTION
#### What is the relevant ticket?

* #73 - relabeling cross-seeded torrents can be tricky, and ensuring they are all handled together as a group is a great way to improve the reliability of the `tqm`. Below changes introduce a more robust and safer way to handle relabeling for cross-seeded torrents, preventing potential data corruption or incomplete moves when TMM is used.

#### What’s this PR do?

* identify torrents that are candidates for relabeling
* if a candidate is part of a non-unique group, it will check if all torrents sharing the same save path are also candidates for relabeling to the same new label
* relabeling will only proceed for the whole group **if all torrents meet the criteria**. This prevents partial moves that could lead to missing data error
* torrents that have already been processed as part of a group will be skipped to avoid redundant checks

#### Where should the reviewer start?

* `cmd/helpers.go` - Update relabelEligibleTorrents to Handle Groups of Torrents
* `pkg/torrentfilemap/torrentfilemap.go` - Add GetTorrentsSharingFiles to TorrentFileMap

#### How should this be manually tested?

See the scenario in this [comment](https://github.com/autobrr/tqm/issues/73#issuecomment-3404281618).

1. Before the change:

```
1. First torrent is missed
2. Relabeling: "rhel-10.0-x86_64-boot.iso" - ARCHIVE | with hardlinks to: "/home/user/ARCHIVE"
3. Relabeling: "rhel-10.0-x86_64-boot.iso" - ARCHIVE | with hardlinks to: "/home/user/ARCHIVE"
4. Relabeling: "rhel-10.0-x86_64-boot.iso" - ARCHIVE | with hardlinks to: "/home/user/ARCHIVE"
5. Relabeling: "rhel-10.0-x86_64-boot.iso" - ARCHIVE | with hardlinks to: "/home/user/ARCHIVE"
```

2. After the change:

```
Part of cross-seed group for "rhel-10.0-x86_64-boot.iso" does not meet relabel criteria: "rhel-10.0-x86_64-boot.iso" (target label: ARCHIVE, group target: )
WARN relabel        : Skipping relabel for cross-seed group of "rhel-10.0-x86_64-boot.iso" as not all torrents meet criteria.
```

#### Risk involved?

* Yes, this needs to be thoroughly tested!

#### Screenshots (if appropriate):

* N/A

#### Does the documentation or dependencies need an update?

* Updated in f4be6c86f6267d5746be545a8ff00b3335ecb59a
