### PR TITLE
feat(priority): add support for configurable torrent processing priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,25 @@ filters:
       - FreeSpaceSet == true && FreeSpaceGB() < 100 && SeedingDays > 30
 ```
 
+## Processing Priority
+
+You can configure the order in which torrents are processed (and removed) by providing a `priority` expression. This is useful when you want to prioritize removing certain torrents when freeing up space (e.g. "big old torrents first").
+
+The `priority` expression is evaluated for each torrent, and torrents are processed in **descending order** of the resulting score (highest score first).
+
+Example:
+
+```yaml
+filters:
+  default:
+    # Prefer removing big and old torrents first
+    # Priority = Size (GB) + Age (Days)
+    priority: "TotalBytes / 1024 / 1024 / 1024 + AddedDays"
+
+    remove:
+      - FreeSpaceSet == true && FreeSpaceGB() < 100
+```
+
 ## regexp2 Pattern Matching
 
 TQM uses the regexp2 library for advanced pattern matching, providing .NET style regex capabilities. This offers several advantages over Go's standard regex package:

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -423,6 +424,15 @@ func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Int
 	hardlinkedCandidates := make(map[string]config.Torrent)
 	fileOverlapCandidates := make(map[string]config.Torrent)
 	candidateReasons := make(map[string]string)
+
+	type removalCandidate struct {
+		Hash     string
+		Torrent  config.Torrent
+		Priority float64
+	}
+
+	candidates := make([]removalCandidate, 0, len(torrents))
+
 	for h, t := range torrents {
 		// should we ignore this torrent?
 		ignore, err := c.ShouldIgnore(ctx, &t)
@@ -438,6 +448,35 @@ func removeEligibleTorrents(ctx context.Context, log *logrus.Entry, c client.Int
 			ignoredTorrents++
 			continue
 		}
+
+		// calculate priority
+		priority, err := c.EvaluatePriority(ctx, &t)
+		if err != nil {
+			log.WithError(err).Errorf("Failed evaluating priority score: %+v", t)
+			continue
+		}
+
+		candidates = append(candidates, removalCandidate{
+			Hash:     h,
+			Torrent:  t,
+			Priority: priority,
+		})
+	}
+
+	// sort candidates by priority
+	slices.SortFunc(candidates, func(a, b removalCandidate) int {
+		if a.Priority > b.Priority {
+			return -1
+		}
+		if a.Priority < b.Priority {
+			return 1
+		}
+		return 0
+	})
+
+	for _, cand := range candidates {
+		h := cand.Hash
+		t := cand.Torrent
 
 		// should we remove this torrent?
 		remove, reason, err := c.ShouldRemoveWithReason(ctx, &t)

--- a/pkg/client/deluge.go
+++ b/pkg/client/deluge.go
@@ -358,6 +358,19 @@ func (c *Deluge) CheckTorrentPause(ctx context.Context, t *config.Torrent) (bool
 	return match, nil
 }
 
+func (c *Deluge) EvaluatePriority(ctx context.Context, t *config.Torrent) (float64, error) {
+	if c.exp.Priority == nil {
+		return 0, nil
+	}
+
+	result, err := expression.EvaluateFloat64Expression(ctx, t, c.exp.Priority)
+	if err != nil {
+		return 0, fmt.Errorf("evaluate priority expression: %v: %w", t.Hash, err)
+	}
+
+	return result, nil
+}
+
 func (c *Deluge) PauseTorrents(ctx context.Context, hashes []string) error {
 	var err error
 	if c.V2 {

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -24,6 +24,7 @@ type Interface interface {
 	ShouldRemove(ctx context.Context, t *config.Torrent) (bool, error)
 	ShouldRemoveWithReason(ctx context.Context, t *config.Torrent) (bool, string, error)
 	CheckTorrentPause(ctx context.Context, t *config.Torrent) (bool, error)
+	EvaluatePriority(ctx context.Context, t *config.Torrent) (float64, error)
 	ShouldRelabel(ctx context.Context, t *config.Torrent) (string, bool, error)
 
 	PauseTorrents(ctx context.Context, hashes []string) error

--- a/pkg/client/qbittorrent.go
+++ b/pkg/client/qbittorrent.go
@@ -452,6 +452,19 @@ func (c *QBittorrent) CheckTorrentPause(ctx context.Context, t *config.Torrent) 
 	return match, nil
 }
 
+func (c *QBittorrent) EvaluatePriority(ctx context.Context, t *config.Torrent) (float64, error) {
+	if c.exp.Priority == nil {
+		return 0, nil
+	}
+
+	result, err := expression.EvaluateFloat64Expression(ctx, t, c.exp.Priority)
+	if err != nil {
+		return 0, fmt.Errorf("evaluate priority expression: %v: %w", t.Hash, err)
+	}
+
+	return result, nil
+}
+
 func (c *QBittorrent) PauseTorrents(ctx context.Context, hashes []string) error {
 	if err := c.client.PauseCtx(ctx, hashes); err != nil {
 		return fmt.Errorf("pause torrents: %v: %w", hashes, err)

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -7,6 +7,7 @@ type FilterConfiguration struct {
 	Ignore          []string
 	Remove          []string
 	Pause           []string
+	Priority        *string
 	DeleteData      *bool
 	Orphan          struct {
 		GracePeriod time.Duration `yaml:"grace_period" koanf:"grace_period"`

--- a/pkg/expression/check.go
+++ b/pkg/expression/check.go
@@ -67,3 +67,25 @@ func CheckTorrentAllMatchWithReason(ctx context.Context, t *config.Torrent, expr
 
 	return true, nil, nil
 }
+
+func EvaluateFloat64Expression(ctx context.Context, t *config.Torrent, expression *CompiledExpression) (float64, error) {
+	env := &evalContext{Torrent: t, ctx: ctx}
+
+	result, err := expr.Run(expression.Program, env)
+	if err != nil {
+		return 0, fmt.Errorf("evaluate expression: %w", err)
+	}
+
+	switch v := result.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	default:
+		return 0, fmt.Errorf("expression result is not a number: %T", result)
+	}
+}

--- a/pkg/expression/compile.go
+++ b/pkg/expression/compile.go
@@ -124,6 +124,19 @@ func Compile(filter *config.FilterConfiguration) (*Expressions, error) {
 		})
 	}
 
+	// compile priority
+	if filter.Priority != nil && *filter.Priority != "" {
+		program, err := expr.Compile(*filter.Priority, expr.Env(exprEnv))
+		if err != nil {
+			return nil, fmt.Errorf("compile priority expression: %q: %w", *filter.Priority, err)
+		}
+
+		exp.Priority = &CompiledExpression{
+			Program: program,
+			Text:    *filter.Priority,
+		}
+	}
+
 	// compile labels
 	for _, labelExpr := range filter.Label {
 		le := &LabelExpression{Name: labelExpr.Name}

--- a/pkg/expression/struct.go
+++ b/pkg/expression/struct.go
@@ -14,11 +14,12 @@ type CompiledExpression struct {
 }
 
 type Expressions struct {
-	Ignores []CompiledExpression
-	Removes []CompiledExpression
-	Pauses  []CompiledExpression
-	Labels  []*LabelExpression
-	Tags    []*TagExpression
+	Ignores  []CompiledExpression
+	Removes  []CompiledExpression
+	Pauses   []CompiledExpression
+	Priority *CompiledExpression
+	Labels   []*LabelExpression
+	Tags     []*TagExpression
 }
 
 type LabelExpression struct {


### PR DESCRIPTION
When using disk space-based cleanup, it is useful to control which torrents are removed first. For example, prioritizing the deletion of old, large torrents over new, small ones.

This PR implements a system where users can provide an expression that assigns a numeric priority score to each torrent. Candidates are then processed in descending order of this score, ensuring that high-priority torrents are removed first until the free disk space requirements are met.

Using this priority system only really makes sense if you use `FreeSpaceGB()` in some rule otherwise the order of operations does not matter.