### PR TITLE
fix(configpath): fallback to binary path if user config dir retrieval fails

### DIFF
--- a/pkg/config/configpath.go
+++ b/pkg/config/configpath.go
@@ -18,7 +18,8 @@ func GetDefaultConfigDirectory(app string, filename string) string {
 	// config dir
 	ucd, err := os.UserConfigDir()
 	if err != nil {
-		panic(fmt.Sprintf("userconfigdir: %v", err))
+		// fallback to binary path
+		return bcd
 	}
 
 	acd := filepath.Join(ucd, app)


### PR DESCRIPTION
PR #72 which adds Docker support is currently blocked by a panic caused by $HOME and/or $XDG_CONFIG_HOME not being defined (see [this](https://github.com/autobrr/tqm/pull/72#issuecomment-3186228808) comment). 

This PR makes it fallback to the binary location instead of panicking.